### PR TITLE
[Feature] Add team selection screen for roster management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ GEMINI.md
 *.md
 test-auth-flow.sh
 ios/
+tmpDocs/

--- a/app/(coach)/(tabs)/coachHome.tsx
+++ b/app/(coach)/(tabs)/coachHome.tsx
@@ -143,7 +143,7 @@ const mapToUpcomingCardFormat = (event: any) => ({
 
 
   const navigationOptions = [
-    { label: "Team Roster", route: "/screens/teamRoster", image: images.teamRoster },
+    { label: "Team Roster", route: "/screens/selectTeamForRoster", image: images.teamRoster },
     { label: "Training Schedule", route: "/coachCalendar", image: images.schedules },
     { label: "Match History", route: "/screens/matchHistory", image: images.matchHistory },
   ];

--- a/app/(coach)/screens/selectTeamForRoster.tsx
+++ b/app/(coach)/screens/selectTeamForRoster.tsx
@@ -1,0 +1,401 @@
+import React, { useState, useEffect, useRef } from "react"
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Dimensions,
+  Animated,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { StatusBar } from "expo-status-bar"
+import { FontAwesome6, Ionicons } from "@expo/vector-icons"
+import { useRouter } from "expo-router"
+import * as Haptics from "expo-haptics"
+import BackButton from "@/components/buttons/BackButton"
+import { TeamResponse } from "@/app/api/Api"
+import { getTeams } from "@/utils/api"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+
+const { width } = Dimensions.get("window")
+
+// Define color constants
+const COLORS = {
+  primary: "#FFD700",
+  primaryDark: "#E6C200",
+  background: "#0C0B0B",
+  card: "#1A1A1A",
+  cardDark: "#141414",
+  text: "#FFFFFF",
+  textSecondary: "#AAAAAA",
+  success: "#4CAF50",
+  warning: "#FFC107",
+  danger: "#FF5252",
+  info: "#2196F3",
+}
+
+const SelectTeamForRoster: React.FC = () => {
+  // State
+  const [teams, setTeams] = useState<TeamResponse[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Animation refs
+  const fadeAnim = useRef(new Animated.Value(0)).current
+
+  // Navigation
+  const router = useRouter()
+
+  // Effects
+  useEffect(() => {
+    // Initial animation
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 800,
+      useNativeDriver: true,
+    }).start()
+
+    // Fetch teams data
+    fetchTeams()
+  }, [])
+
+  // Methods
+  const fetchTeams = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      
+      // Get user token from AsyncStorage
+      const storedUser = await AsyncStorage.getItem("user")
+      if (!storedUser) {
+        throw new Error("User not found. Please log in again.")
+      }
+      
+      const user = JSON.parse(storedUser)
+      const token = user.token || await AsyncStorage.getItem("authToken")
+      
+      if (!token) {
+        throw new Error("Authentication token not found. Please log in again.")
+      }
+
+      const teamsData = await getTeams(token)
+      setTeams(Array.isArray(teamsData) ? teamsData : [])
+    } catch (error) {
+      console.error("Error fetching teams:", error)
+      setError((error as Error).message)
+      setTeams([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    await fetchTeams()
+    setRefreshing(false)
+  }
+
+  const handleTeamPress = (team: TeamResponse) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
+    // Navigate to team roster screen with selected team ID
+    router.push(`/screens/teamRoster?teamId=${team.id}&teamName=${encodeURIComponent(team.name || "")}`)
+  }
+
+  // Render methods
+  const renderHeader = () => (
+    <View style={styles.header}>
+      <BackButton />
+      <View style={styles.headerTitleContainer}>
+        <Text style={styles.headerTitle}>Select Team</Text>
+      </View>
+      <View style={styles.headerActions}>
+        {/* Empty view for alignment */}
+        <View style={{ width: 40 }} />
+      </View>
+    </View>
+  )
+
+  const renderTeamItem = ({ item }: { item: TeamResponse }) => (
+    <Animated.View
+      style={[
+        styles.teamCardContainer,
+        {
+          transform: [
+            {
+              scale: fadeAnim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0.9, 1],
+              }),
+            },
+          ],
+        },
+      ]}
+    >
+      <TouchableOpacity
+        style={styles.teamCard}
+        activeOpacity={0.7}
+        onPress={() => handleTeamPress(item)}
+      >
+        <View style={styles.teamCardContent}>
+          {/* Team Icon */}
+          <View style={styles.teamIcon}>
+            <FontAwesome6 name="users" size={32} color={COLORS.primary} />
+          </View>
+
+          {/* Team Info */}
+          <View style={styles.teamInfo}>
+            <Text style={styles.teamName}>{item.name}</Text>
+            
+            <View style={styles.teamDetailRow}>
+              {item.capacity && (
+                <View style={styles.capacityBadge}>
+                  <Text style={styles.capacityText}>
+                    Capacity: {item.capacity}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {item.coach && (
+              <View style={styles.coachInfo}>
+                <Ionicons name="person" size={16} color={COLORS.textSecondary} />
+                <Text style={styles.coachText}>
+                  Coach: {item.coach.name || "Unknown"}
+                </Text>
+              </View>
+            )}
+
+            {item.roster && item.roster.length > 0 && (
+              <View style={styles.rosterInfo}>
+                <FontAwesome6 name="users" size={14} color={COLORS.textSecondary} />
+                <Text style={styles.rosterText}>
+                  {item.roster.length} player{item.roster.length !== 1 ? 's' : ''}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* Arrow Icon */}
+          <View style={styles.arrowIcon}>
+            <Ionicons name="chevron-forward" size={24} color={COLORS.primary} />
+          </View>
+        </View>
+      </TouchableOpacity>
+    </Animated.View>
+  )
+
+  const renderEmptyList = () => {
+    if (loading) {
+      return (
+        <View style={styles.emptyContainer}>
+          <ActivityIndicator size="large" color={COLORS.primary} />
+          <Text style={styles.emptyText}>Loading teams...</Text>
+        </View>
+      )
+    }
+
+    if (error) {
+      return (
+        <View style={styles.emptyContainer}>
+          <FontAwesome6 name="triangle-exclamation" size={50} color={COLORS.danger} />
+          <Text style={styles.emptyText}>Error loading teams</Text>
+          <Text style={styles.emptySubtext}>{error}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={fetchTeams}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      )
+    }
+
+    return (
+      <View style={styles.emptyContainer}>
+        <FontAwesome6 name="users-slash" size={50} color={COLORS.textSecondary} />
+        <Text style={styles.emptyText}>No teams found</Text>
+        <Text style={styles.emptySubtext}>You don't have any teams assigned</Text>
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar translucent style="light" />
+
+      <Animated.View style={[styles.content, { opacity: fadeAnim }]}>
+        {renderHeader()}
+
+        <View style={styles.instructionContainer}>
+          <Text style={styles.instructionText}>
+            Choose a team to view its roster
+          </Text>
+        </View>
+
+        <FlatList
+          data={teams}
+          keyExtractor={(item) => item.id || "unknown"}
+          renderItem={renderTeamItem}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.teamsList}
+          ListEmptyComponent={renderEmptyList}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+        />
+      </Animated.View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#333",
+  },
+  headerTitleContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: "bold",
+    color: COLORS.text,
+  },
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  instructionContainer: {
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  instructionText: {
+    color: COLORS.textSecondary,
+    fontSize: 16,
+    textAlign: "center",
+  },
+  teamsList: {
+    paddingBottom: 20,
+  },
+  teamCardContainer: {
+    marginBottom: 16,
+  },
+  teamCard: {
+    backgroundColor: COLORS.card,
+    borderRadius: 12,
+    overflow: "hidden",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  teamCardContent: {
+    flexDirection: "row",
+    padding: 16,
+    alignItems: "center",
+  },
+  teamIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: `${COLORS.primary}20`,
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 16,
+  },
+  teamInfo: {
+    flex: 1,
+  },
+  teamName: {
+    color: COLORS.text,
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 8,
+  },
+  teamDetailRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 6,
+  },
+  capacityBadge: {
+    backgroundColor: `${COLORS.info}30`,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  capacityText: {
+    color: COLORS.info,
+    fontSize: 12,
+    fontWeight: "bold",
+  },
+  coachInfo: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  coachText: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    marginLeft: 6,
+  },
+  rosterInfo: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  rosterText: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    marginLeft: 6,
+  },
+  arrowIcon: {
+    marginLeft: 12,
+  },
+  emptyContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 60,
+    paddingHorizontal: 20,
+  },
+  emptyText: {
+    color: COLORS.text,
+    fontSize: 18,
+    fontWeight: "bold",
+    marginTop: 16,
+    textAlign: "center",
+  },
+  emptySubtext: {
+    color: COLORS.textSecondary,
+    fontSize: 14,
+    marginTop: 8,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  retryButton: {
+    backgroundColor: COLORS.primary,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginTop: 16,
+  },
+  retryButtonText: {
+    color: "#000",
+    fontWeight: "bold",
+    fontSize: 16,
+  },
+})
+
+export default SelectTeamForRoster

--- a/app/(coach)/screens/teamRoster.tsx
+++ b/app/(coach)/screens/teamRoster.tsx
@@ -438,16 +438,19 @@ const TeamRoster: React.FC = () => {
           <Text style={styles.statValue}>{teamStats.injuredPlayers}</Text>
           <Text style={styles.statLabel}>Injured</Text>
         </View>
+        {/* Temporarily hidden until backend supports player stats
         <View style={styles.statItem}>
           <Text style={styles.statValue}>{teamStats.avgPPG.toFixed(1)}</Text>
           <Text style={styles.statLabel}>PPG</Text>
         </View>
+        */}
       </View>
     </View>
   )
 
   const renderPositionTabs = () => (
     <View>
+      {/* Temporarily hidden until backend supports position data
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -472,6 +475,7 @@ const TeamRoster: React.FC = () => {
           </TouchableOpacity>
         ))}
       </ScrollView>
+      */}
     </View>
   )
   
@@ -533,12 +537,15 @@ const TeamRoster: React.FC = () => {
             </Text>
 
             <View style={styles.playerDetailRow}>
+              {/* Temporarily hidden until backend supports position data
               <View style={styles.positionBadge}>
                 <Text style={styles.positionText}>{item.position}</Text>
               </View>
+              */}
               {getStatusBadge(item.status)}
             </View>
 
+            {/* Temporarily hidden until backend supports player stats
             <View style={styles.statsRow}>
               <View style={styles.statColumn}>
                 <Text style={styles.statValue}>{item.stats.ppg.toFixed(1)}</Text>
@@ -553,9 +560,10 @@ const TeamRoster: React.FC = () => {
                 <Text style={styles.statLabel}>APG</Text>
               </View>
             </View>
+            */}
           </View>
 
-          {/* Quick Actions */}
+          {/* Temporarily hidden until backend supports player actions
           <View style={styles.quickActions}>
             <TouchableOpacity
               style={styles.quickActionButton}
@@ -579,6 +587,7 @@ const TeamRoster: React.FC = () => {
               <Feather name="message-circle" size={22} color={COLORS.primary} />
             </TouchableOpacity>
           </View>
+          */}
         </View>
       </TouchableOpacity>
     </Animated.View>
@@ -874,6 +883,7 @@ const TeamRoster: React.FC = () => {
                   </View>
                 </View>
 
+                {/* Temporarily hidden until backend supports detailed player stats
                 <View style={styles.playerModalSection}>
                   <Text style={styles.playerModalSectionTitle}>Key Stats</Text>
                   <View style={styles.playerModalStatsGrid}>
@@ -913,6 +923,7 @@ const TeamRoster: React.FC = () => {
                     </View>
                   </View>
                 </View>
+                */}
 
                 {selectedPlayer.lastFiveGames && (
                   <View style={styles.playerModalSection}>

--- a/app/(coach)/screens/teamRoster.tsx
+++ b/app/(coach)/screens/teamRoster.tsx
@@ -17,10 +17,12 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context"
 import { StatusBar } from "expo-status-bar"
 import { FontAwesome6, Ionicons, MaterialIcons, MaterialCommunityIcons, AntDesign, Feather } from "@expo/vector-icons"
-import { useRouter } from "expo-router"
+import { useRouter, useLocalSearchParams } from "expo-router"
 import * as Haptics from "expo-haptics"
-import players from "../data/players"
 import BackButton from "@/components/buttons/BackButton"
+import { getTeamById } from "@/utils/api"
+import { TeamResponse, ApiInternalDomainsTeamDtoRosterMemberInfo } from "@/app/api/Api"
+import AsyncStorage from "@react-native-async-storage/async-storage"
 
 const { width, height } = Dimensions.get("window")
 
@@ -62,10 +64,45 @@ const POSITION_NAMES = {
   C: "Center",
 }
 
+// Helper function to map API roster data to Player interface
+const mapRosterMemberToPlayer = (member: ApiInternalDomainsTeamDtoRosterMemberInfo, index: number): Player => ({
+  id: member.id || `player-${index}`,
+  firstName: member.name?.split(' ')[0] || "Unknown",
+  lastName: member.name?.split(' ').slice(1).join(' ') || "Player",
+  number: index + 1, // Since API doesn't have jersey numbers yet
+  position: "PG" as PlayerPosition, // Default position since API doesn't have this
+  height: "6'0\"", // Default height since API doesn't have this
+  weight: 180, // Default weight since API doesn't have this
+  age: 22, // Default age since API doesn't have this
+  experience: 2, // Default experience since API doesn't have this
+  college: "Unknown", // Default college since API doesn't have this
+  image: "https://images.unsplash.com/photo-1546519638-68e109498ffc?q=80&w=1780&auto=format&fit=crop", // Default image
+  status: "Active" as PlayerStatus, // Default status since API doesn't have this
+  stats: {
+    ppg: member.points || 0,
+    rpg: member.rebounds || 0,
+    apg: member.assists || 0,
+    spg: member.steals || 0,
+    bpg: 0, // API doesn't have blocks
+    fg: 0.45, // Default field goal percentage
+    threePt: 0.35, // Default three-point percentage
+    ft: 0.75, // Default free throw percentage
+    mpg: 25, // Default minutes per game
+    topg: 2, // Default turnovers
+  },
+})
+
 const TeamRoster: React.FC = () => {
+  // Get URL parameters
+  const params = useLocalSearchParams()
+  const teamId = params.teamId as string
+  const teamName = params.teamName as string
+
   // State
-  const [allPlayers, setAllPlayers] = useState<Player[]>(players)
-  const [filteredPlayers, setFilteredPlayers] = useState<Player[]>(players)
+  const [allPlayers, setAllPlayers] = useState<Player[]>([])
+  const [filteredPlayers, setFilteredPlayers] = useState<Player[]>([])
+  const [teamData, setTeamData] = useState<TeamResponse | null>(null)
+  const [apiError, setApiError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTab, setActiveTab] = useState<"all" | PlayerPosition>("all")
   const [sortBy, setSortBy] = useState<"name" | "number" | "ppg" | "position">("name")
@@ -176,20 +213,52 @@ const TeamRoster: React.FC = () => {
   }, [showPlayerModal])
 
   // Methods
-  const fetchPlayers = () => {
-    setLoading(true)
-    // Simulate API call
-    setTimeout(() => {
+  const fetchPlayers = async () => {
+    try {
+      setLoading(true)
+      setApiError(null)
+
+      // Validate teamId is provided
+      if (!teamId) {
+        throw new Error("No team selected. Please go back and select a team.")
+      }
+
+      // Get user token from AsyncStorage
+      const storedUser = await AsyncStorage.getItem("user")
+      if (!storedUser) {
+        throw new Error("User not found. Please log in again.")
+      }
+      
+      const user = JSON.parse(storedUser)
+      const token = user.token || await AsyncStorage.getItem("authToken")
+      
+      if (!token) {
+        throw new Error("Authentication token not found. Please log in again.")
+      }
+
+      // Fetch team data from API
+      const team = await getTeamById(teamId, token)
+      setTeamData(team)
+
+      // Map roster members to Player objects
+      const playersData = team.roster ? team.roster.map(mapRosterMemberToPlayer) : []
+      setAllPlayers(playersData)
+
+    } catch (error) {
+      console.error("Error fetching team data:", error)
+      setApiError((error as Error).message)
+      // Clear data on error - no fallback to mock data
+      setAllPlayers([])
+      setTeamData(null)
+    } finally {
       setLoading(false)
-    }, 1000)
+    }
   }
 
-  const handleRefresh = () => {
+  const handleRefresh = async () => {
     setRefreshing(true)
-    // Simulate refresh
-    setTimeout(() => {
-      setRefreshing(false)
-    }, 1500)
+    await fetchPlayers()
+    setRefreshing(false)
   }
 
   const filterAndSortPlayers = () => {
@@ -315,7 +384,9 @@ const TeamRoster: React.FC = () => {
 
       <BackButton />
       <View style={styles.headerTitleContainer}>
-        <Text style={styles.headerTitle}>Team Roster</Text>
+        <Text style={styles.headerTitle}>
+          {teamData?.name || teamName || "Team Roster"}
+        </Text>
         <TouchableOpacity style={styles.infoButton} onPress={() => setShowPositionLegend(!showPositionLegend)}>
           <Ionicons name="information-circle-outline" size={22} color={COLORS.primary} />
         </TouchableOpacity>
@@ -523,14 +594,41 @@ const TeamRoster: React.FC = () => {
       )
     }
 
+    if (apiError) {
+      return (
+        <View style={styles.emptyContainer}>
+          <FontAwesome6 name="wifi-slash" size={50} color={COLORS.danger} />
+          <Text style={styles.emptyText}>Unable to load team data</Text>
+          <Text style={styles.emptySubtext}>Please check your connection and try again</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={fetchPlayers}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      )
+    }
+
+    // Check if it's due to filters
+    if (allPlayers.length > 0 && filteredPlayers.length === 0) {
+      return (
+        <View style={styles.emptyContainer}>
+          <FontAwesome6 name="filter" size={50} color={COLORS.textSecondary} />
+          <Text style={styles.emptyText}>No players match your filters</Text>
+          <Text style={styles.emptySubtext}>Try adjusting your filters</Text>
+          <TouchableOpacity style={styles.resetButton} onPress={resetFilters}>
+            <Text style={styles.resetButtonText}>Reset Filters</Text>
+          </TouchableOpacity>
+        </View>
+      )
+    }
+
+    // No players in team
     return (
       <View style={styles.emptyContainer}>
         <FontAwesome6 name="users-slash" size={50} color={COLORS.textSecondary} />
-        <Text style={styles.emptyText}>No players found</Text>
-        <Text style={styles.emptySubtext}>Try adjusting your filters</Text>
-        <TouchableOpacity style={styles.resetButton} onPress={resetFilters}>
-          <Text style={styles.resetButtonText}>Reset Filters</Text>
-        </TouchableOpacity>
+        <Text style={styles.emptyText}>No players in this team</Text>
+        <Text style={styles.emptySubtext}>
+          {teamData?.name ? `${teamData.name} doesn't have any players yet` : "This team is empty"}
+        </Text>
       </View>
     )
   }
@@ -905,6 +1003,17 @@ const TeamRoster: React.FC = () => {
       <Animated.View style={[styles.content, { opacity: fadeAnim }]}>
         {renderHeader()}
         {renderSearchBar()}
+        
+        {/* Show API error if present */}
+        {apiError && (
+          <View style={styles.errorContainer}>
+            <FontAwesome6 name="triangle-exclamation" size={16} color={COLORS.danger} />
+            <Text style={[styles.errorText, { color: COLORS.danger }]}>
+              Failed to load team data: {apiError}
+            </Text>
+          </View>
+        )}
+        
         {renderTeamStats()}
         {renderPositionTabs()}
         {renderPositionLegend()}
@@ -1005,6 +1114,21 @@ const styles = StyleSheet.create({
   },
   clearSearch: {
     padding: 5,
+  },
+  errorContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: `${COLORS.danger}20`,
+    padding: 12,
+    marginTop: 16,
+    borderRadius: 8,
+    borderLeftWidth: 4,
+    borderLeftColor: COLORS.danger,
+  },
+  errorText: {
+    fontSize: 14,
+    marginLeft: 8,
+    flex: 1,
   },
   statsContainer: {
     marginTop: 16,
@@ -1221,6 +1345,18 @@ const styles = StyleSheet.create({
   resetButtonText: {
     color: COLORS.text,
     fontWeight: "bold",
+  },
+  retryButton: {
+    backgroundColor: COLORS.primary,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginTop: 16,
+  },
+  retryButtonText: {
+    color: "#000",
+    fontWeight: "bold",
+    fontSize: 16,
   },
   modalOverlay: {
     flex: 1,

--- a/app/api/Api.ts
+++ b/app/api/Api.ts
@@ -10,23 +10,25 @@
  * ---------------------------------------------------------------
  */
 
-export interface CourseRequestDto {
-  description?: string;
-  name: string;
-}
-
-export interface CourseResponseDto {
-  created_at?: string;
-  description?: string;
+export interface ApiInternalDomainsTeamDtoRosterMemberInfo {
+  assists?: number;
+  country?: string;
+  email?: string;
   id?: string;
+  losses?: number;
   name?: string;
-  updated_at?: string;
+  points?: number;
+  rebounds?: number;
+  steals?: number;
+  wins?: number;
 }
 
 export interface CustomerAthleteRegistrationRequestDto {
-  age: number;
   country_code?: string;
+  /** @example "2000-01-01" */
+  dob: string;
   first_name: string;
+  gender?: "M" | "F";
   has_consent_to_email_marketing?: boolean;
   has_consent_to_sms?: boolean;
   last_name: string;
@@ -45,23 +47,13 @@ export interface CustomerAthleteResponseDto {
 }
 
 export interface CustomerChildRegistrationRequestDto {
-  age: number;
   country_code?: string;
+  /** @example "2000-01-01" */
+  dob: string;
   first_name: string;
+  gender?: "M" | "F";
   last_name: string;
   waivers?: CustomerWaiverSigningRequestDto[];
-}
-
-export interface CustomerMembershipPlansResponseDto {
-  created_at?: string;
-  customer_id?: string;
-  id?: string;
-  membership_name?: string;
-  membership_plan_id?: string;
-  renewal_date?: string;
-  start_date?: string;
-  status?: string;
-  updated_at?: string;
 }
 
 export interface CustomerMembershipResponseDto {
@@ -73,9 +65,11 @@ export interface CustomerMembershipResponseDto {
 }
 
 export interface CustomerParentRegistrationRequestDto {
-  age: number;
   country_code?: string;
+  /** @example "2000-01-01" */
+  dob: string;
   first_name: string;
+  gender?: "M" | "F";
   has_consent_to_email_marketing?: boolean;
   has_consent_to_sms?: boolean;
   last_name: string;
@@ -84,9 +78,9 @@ export interface CustomerParentRegistrationRequestDto {
 }
 
 export interface CustomerResponse {
-  age?: number;
   athlete_info?: CustomerAthleteResponseDto;
   country_code?: string;
+  dob?: string;
   email?: string;
   first_name?: string;
   hubspot_id?: string;
@@ -110,69 +104,186 @@ export interface CustomerWaiverSigningRequestDto {
   waiver_url: string;
 }
 
-export interface EnrollmentCreateRequestDto {
-  customer_id: string;
-  event_id: string;
-}
-
-export interface EnrollmentResponseDto {
-  checked_in_at?: string;
-  created_at?: string;
-  customer_id?: string;
-  event_id?: string;
-  id?: string;
-  is_cancelled?: boolean;
-  updated_at?: string;
-}
-
-export interface EventRequestDto {
-  /** @example "00000000-0000-0000-0000-000000000000" */
-  course_id?: string;
+export interface EventCreateRequestDto {
+  /** @example 100 */
+  capacity?: number;
   /** @example "THURSDAY" */
-  day: string;
-  /** @example "00000000-0000-0000-0000-000000000000" */
-  game_id?: string;
+  day?: string;
+  /** @example "23:00:00+00:00" */
+  end_at: string;
   /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
   location_id?: string;
   /** @example "f0e21457-75d4-4de6-b765-5ee13221fd72" */
-  practice_id?: string;
+  program_id?: string;
   /** @example "2023-10-05T07:00:00Z" */
-  program_end_at: string;
+  recurrence_end_at: string;
   /** @example "2023-10-05T07:00:00Z" */
-  program_start_at: string;
+  recurrence_start_at: string;
   /** @example "23:00:00+00:00" */
-  session_end_time: string;
-  /** @example "23:00:00+00:00" */
-  session_start_time: string;
+  start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  team_id?: string;
 }
 
-export interface EventResponseDto {
-  capacity?: number;
-  course_id?: string;
-  course_name?: string;
-  day?: string;
-  game_id?: string;
-  game_name?: string;
+export interface EventCustomerResponseDto {
+  email?: string;
+  first_name?: string;
+  gender?: string;
+  has_cancelled_enrollment?: boolean;
   id?: string;
-  location_address?: string;
-  location_id?: string;
-  location_name?: string;
-  practice_id?: string;
-  practice_name?: string;
-  program_end_at?: string;
-  program_start_at?: string;
+  last_name?: string;
+  phone?: string;
+}
+
+export interface EventDeleteRequestDto {
+  /** @minItems 1 */
+  ids: string[];
+}
+
+export interface EventEventResponseDto {
+  capacity?: number;
+  created_by?: EventPersonResponseDto;
+  customers?: EventCustomerResponseDto[];
+  end_at?: string;
+  id?: string;
+  location?: EventLocationInfo;
+  program?: EventProgramInfo;
+  staff?: EventStaffResponseDto[];
+  start_at?: string;
+  team?: EventTeamInfo;
+  updated_by?: EventPersonResponseDto;
+}
+
+export interface EventLocation {
+  address?: string;
+  id?: string;
+  name?: string;
+}
+
+export interface EventLocationInfo {
+  address?: string;
+  id?: string;
+  name?: string;
+}
+
+export interface EventPersonResponseDto {
+  first_name?: string;
+  id?: string;
+  last_name?: string;
+}
+
+export interface EventProgram {
+  id?: string;
+  name?: string;
+  type?: string;
+}
+
+export interface EventProgramInfo {
+  id?: string;
+  name?: string;
+  type?: string;
+}
+
+export interface EventScheduleResponseDto {
+  day?: string;
+  location?: EventLocation;
+  program?: EventProgram;
+  recurrence_end_at?: string;
+  recurrence_start_at?: string;
   session_end_at?: string;
   session_start_at?: string;
+  team?: EventTeam;
+}
+
+export interface EventStaffResponseDto {
+  email?: string;
+  first_name?: string;
+  gender?: string;
+  id?: string;
+  last_name?: string;
+  phone?: string;
+  role_name?: string;
+}
+
+export interface EventTeam {
+  id?: string;
+  name?: string;
+}
+
+export interface EventTeamInfo {
+  id?: string;
+  name?: string;
+}
+
+export interface EventUpdateEventsRequestDto {
+  /** @example 100 */
+  new_capacity?: number;
+  /** @example "23:00:00+00:00" */
+  new_event_end_at: string;
+  /** @example "21:00:00+00:00" */
+  new_event_start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  new_location_id?: string;
+  /** @example "f0e21457-75d4-4de6-b765-5ee13221fd72" */
+  new_program_id?: string;
+  /** @example "2023-10-05T07:00:00Z" */
+  new_recurrence_end_at: string;
+  /** @example "2023-10-05T07:00:00Z" */
+  new_recurrence_start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  new_team_id?: string;
+  /** @example 100 */
+  original_capacity?: number;
+  /** @example "13:00:00+00:00" */
+  original_event_end_at: string;
+  /** @example "10:00:00+00:00" */
+  original_event_start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  original_location_id?: string;
+  /** @example "f0e21457-75d4-4de6-b765-5ee13221fd72" */
+  original_program_id?: string;
+  /** @example "2023-10-05T07:00:00Z" */
+  original_recurrence_end_at: string;
+  /** @example "2023-10-05T07:00:00Z" */
+  original_recurrence_start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  original_team_id?: string;
+}
+
+export interface EventUpdateRequestDto {
+  /** @example 100 */
+  capacity?: number;
+  /** @example "2023-10-05T07:00:00Z" */
+  end_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  location_id?: string;
+  /** @example "f0e21457-75d4-4de6-b765-5ee13221fd72" */
+  program_id?: string;
+  /** @example "2023-10-05T07:00:00Z" */
+  start_at: string;
+  /** @example "0bab3927-50eb-42b3-9d6b-2350dd00a100" */
+  team_id?: string;
 }
 
 export interface GameRequestDto {
-  name?: string;
+  description?: string;
+  lose_score?: number;
+  lose_team?: string;
+  name: string;
+  win_score?: number;
+  win_team?: string;
 }
 
 export interface GameResponseDto {
+  created_at?: string;
+  description?: string;
   id?: string;
+  lose_score?: number;
+  lose_team?: string;
   name?: string;
-  video_link?: string;
+  updated_at?: string;
+  win_score?: number;
+  win_team?: string;
 }
 
 export interface HaircutBarberServiceResponseDto {
@@ -211,9 +322,22 @@ export interface HaircutRequestDto {
   begin_time: string;
   /** @example "2023-10-05T07:00:00Z" */
   end_time: string;
+  /** @example "Haircut" */
+  service_name: string;
+}
+
+export interface IdentityAthleteResponseDto {
+  assists?: number;
+  losses?: number;
+  points?: number;
+  rebounds?: number;
+  steals?: number;
+  wins?: number;
 }
 
 export interface IdentityMembershipReadResponseDto {
+  membership_benefits?: string;
+  membership_description?: string;
   membership_name?: string;
   plan_name?: string;
   renewal_date?: string;
@@ -221,7 +345,8 @@ export interface IdentityMembershipReadResponseDto {
 }
 
 export interface IdentityUserAuthenticationResponseDto {
-  age?: number;
+  age?: string;
+  athlete_info?: IdentityAthleteResponseDto;
   country_code?: string;
   email?: string;
   first_name?: string;
@@ -253,6 +378,7 @@ export interface MembershipRequestDto {
 }
 
 export interface MembershipResponse {
+  benefits?: string;
   created_at?: string;
   description?: string;
   id?: string;
@@ -264,51 +390,59 @@ export interface MembershipPlanPlanRequestDto {
   amt_periods?: number;
   membership_id: string;
   name?: string;
-  payment_frequency: string;
-  price: string;
+  stripe_joining_fees_id?: string;
+  stripe_price_id: string;
 }
 
 export interface MembershipPlanPlanResponse {
   amt_periods?: number;
   created_at?: string;
   id?: string;
-  joining_fees?: string;
   membership_id?: string;
   name?: string;
-  payment_frequency?: string;
-  price?: string;
+  stripe_joining_fees_id?: string;
+  stripe_price_id?: string;
   updated_at?: string;
 }
 
-export interface PracticeLevelsResponse {
+export interface PaymentCheckoutResponseDto {
+  payment_url?: string;
+}
+
+export interface ProgramLevelsResponse {
   levels?: string[];
 }
 
-export interface PracticeRequestDto {
+export interface ProgramRequestDto {
+  capacity?: number;
   description?: string;
   level: string;
   name: string;
+  type: string;
 }
 
-export interface PracticeResponse {
+export interface ProgramResponse {
+  capacity?: number;
   created_at?: string;
   description?: string;
   id?: string;
   level?: string;
   name?: string;
+  type?: string;
   updated_at?: string;
 }
 
-export interface PurchaseCheckoutResponseDto {
-  payment_url?: string;
+export interface StaffCoachStatsResponseDto {
+  losses?: number;
+  wins?: number;
 }
 
-export type PurchaseSquareWebhookEventDto = object;
-
 export interface StaffRegistrationRequestDto {
-  age: number;
   country_code?: string;
+  /** @example "2000-01-01" */
+  dob: string;
   first_name: string;
+  gender?: "M" | "F";
   is_active_staff?: boolean;
   last_name: string;
   /** @example "+15141234567" */
@@ -322,6 +456,7 @@ export interface StaffRequestDto {
 }
 
 export interface StaffResponseDto {
+  coach_stats?: StaffCoachStatsResponseDto;
   country_code?: string;
   created_at?: string;
   email?: string;
@@ -335,17 +470,40 @@ export interface StaffResponseDto {
   updated_at?: string;
 }
 
+export interface TeamCoach {
+  email?: string;
+  id?: string;
+  name?: string;
+}
+
 export interface TeamRequestDto {
   capacity: number;
+  /** @example "faae4b3a-ad9f-463c-ae4b-3aad9fb63c9b" */
   coach_id?: string;
   name: string;
 }
 
 export interface TeamResponse {
   capacity?: number;
-  coach_id?: string;
+  coach?: TeamCoach;
   created_at?: string;
   id?: string;
   name?: string;
+  roster?: ApiInternalDomainsTeamDtoRosterMemberInfo[];
   updated_at?: string;
+}
+
+export interface UserUpdateRequestDto {
+  /** @example "US" */
+  country_alpha2_code: string;
+  /** @example "2000-01-01" */
+  dob: string;
+  email?: string;
+  first_name: string;
+  gender?: "M" | "F";
+  has_marketing_email_consent: boolean;
+  has_sms_consent: boolean;
+  last_name: string;
+  parent_id?: string;
+  phone?: string;
 }

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -238,6 +238,58 @@ export const registerUser = async (
   }
 };
 
+// 🔹 **Team API Functions**
+
+// Get all teams for the authenticated coach
+export const getTeams = async (token: string): Promise<any> => {
+  try {
+    const firebaseUser = getAuth().currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
+    }
+
+    const firebaseToken = await firebaseUser.getIdToken(true);
+    
+    const response = await axios.get(`${API_URL}/secure/teams`, {
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "firebase_token": firebaseToken,
+        "Content-Type": "application/json",
+      },
+    });
+    
+    return response.data;
+  } catch (error) {
+    console.error("❌ Failed to fetch teams:", (error as any).response?.data || (error as any).message);
+    throw error;
+  }
+};
+
+// Get team details by ID including roster
+export const getTeamById = async (teamId: string, token: string): Promise<any> => {
+  try {
+    const firebaseUser = getAuth().currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
+    }
+
+    const firebaseToken = await firebaseUser.getIdToken(true);
+    
+    const response = await axios.get(`${API_URL}/teams/${teamId}`, {
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "firebase_token": firebaseToken,
+        "Content-Type": "application/json",
+      },
+    });
+    
+    return response.data;
+  } catch (error) {
+    console.error(`❌ Failed to fetch team ${teamId}:`, (error as any).response?.data || (error as any).message);
+    throw error;
+  }
+};
+
 export const getMembershipByCustomerId = async (customerId: string) => {
   const firebaseUser = getAuth().currentUser;
 


### PR DESCRIPTION
# :clipboard: Title
Add team selection screen for roster management

# :sparkles: Changes Made
- Created new team selection screen with API integration
- Updated team roster to receive team parameters from selection
- Removed mock data fallbacks, implemented production API integration
- Added `getTeams` and `getTeamById` functions to API utils
- Updated navigation flow: coachHome → selectTeamForRoster → teamRoster
- Temporarily hidden unsupported player features (PPG/RPG/APG stats, position data)

# :brain: Reason for Changes
- Backend now provides real team APIs, replacing previous mock data approach
- Coaches need to select specific teams before viewing rosters for better performance
- Hidden features that backend doesn't yet support to avoid displaying mock/default data

# :test_tube: Testing Performed
- [x] Mobile App tested via Expo emulator 
- [x] Backend APIs tested (getTeams, getTeamById)
- [x] No console errors
- [x] Navigation flow works correctly
- [x] Error handling for API failures tested
- [x] Real API data displays properly

# :spiral_note_pad: Notes for Reviewer
- All hidden features are commented (not deleted) for easy restoration
- Real API integration replaces all previous mock data
- Error states properly handle API failures
- Branch created from master with clean history