### PR TITLE
[Bugfix] Fix React Native text rendering error in membership screen

### DIFF
--- a/app/(athlete)/screens/membership.tsx
+++ b/app/(athlete)/screens/membership.tsx
@@ -153,16 +153,16 @@ const MembershipScreen: React.FC = () => {
 
   if (status === 'loading') {
     return (
-      <SafeAreaView className="flex-1 bg-[#0C0B0B]">
-        <StatusBar translucent backgroundColor="transparent" style="light" />
+      <SafeAreaView className="flex-1 bg-[#0C0B0B]">
+        <StatusBar translucent backgroundColor="transparent" style="light" />
 
-        {/* Header */}
-        <View className="flex-row items-center py-3 px-4 border-b border-[#222222]">
-          <BackButton />
-          <Text className="text-white-100 text-xl font-bold ml-3">Membership</Text>
-        </View>
+        {/* Header */}
+        <View className="flex-row items-center py-3 px-4 border-b border-[#222222]">
+          <BackButton />
+          <Text className="text-white-100 text-xl font-bold ml-3">Membership</Text>
+        </View>
 
-        {/* Loading State - Show content with loading indicator */}
+        {/* Loading State - Show content with loading indicator */}
         <MembershipPurchaseList
           onPurchaseSuccess={refreshMembershipData}
           onOpenPaymentWebView={handleOpenPaymentWebView}
@@ -192,7 +192,7 @@ const MembershipScreen: React.FC = () => {
             </View>
           }
         />
-      </SafeAreaView>
+      </SafeAreaView>
     );
   }
 
@@ -238,7 +238,7 @@ const MembershipScreen: React.FC = () => {
       </View>
 
       {/* Content */}
-      <>
+      <View className="flex-1">
         {userMemberships.length > 0 ? (
           <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
             <View className="px-4 py-3">
@@ -273,7 +273,7 @@ const MembershipScreen: React.FC = () => {
             }
           />
         )}
-      </>
+      </View>
 
       {/* Payment WebView Modal */}
       <Modal


### PR DESCRIPTION
# :clipboard: Title
Fix React Native text rendering error in membership screen

# :sparkles: Changes Made
- Replace empty Fragment `<></>` with `<View className="flex-1">` component
- Prevent "Text strings must be rendered within a <Text> component" error
- Maintain proper layout structure with flex-1 styling

# :brain: Reason for Changes
Empty Fragment usage in conditional rendering was causing React Native to incorrectly handle text rendering, resulting in app crashes with "Text strings must be rendered within a <Text> component" error.

# :test_tube: Testing Performed
- [x] Mobile App tested via Expo / emulator
- [x] No console errors (Frontend)
- [x] Mobile app builds successfully
- [x] Membership screen loads without errors in loading, error, and success states

# :link: Related Issue
Fixes the text rendering bug reported in membership.tsx line 156

# Notes for Reviewer
This is a minimal, targeted fix that replaces problematic Fragment usage with a standard View component while preserving all existing functionality and styling.