### PR TITLE
[Feature] Display next payment date on membership page

### DIFF
--- a/components/membership/MembershipDetails.tsx
+++ b/components/membership/MembershipDetails.tsx
@@ -25,6 +25,7 @@ interface MembershipData {
   price?: string;
   start_date?: string;
   renewal_date?: string;
+  next_payment_date?: string | null;
   status?: string;
   benefits?: string;
 }
@@ -154,14 +155,16 @@ const MembershipDetails: React.FC<MembershipDetailsProps> = ({
           </View>
 
           {/* Card Footer */}
-          <View style={styles.cardFooter}>
-            <View style={styles.footerItem}>
-              <FontAwesomeIcon icon={faCalendarAlt} color="#000000" size={14} />
-              <Text style={styles.footerText}>
-                Next renewal: {formatDate(membership.renewal_date)}
-              </Text>
+          {membership.next_payment_date && (
+            <View style={styles.cardFooter}>
+              <View style={styles.footerItem}>
+                <FontAwesomeIcon icon={faCalendarAlt} color="#000000" size={14} />
+                <Text style={styles.footerText}>
+                  Next Payment Date: {formatDate(membership.next_payment_date)}
+                </Text>
+              </View>
             </View>
-          </View>
+          )}
         </LinearGradient>
       </View>
 
@@ -241,13 +244,15 @@ const MembershipDetails: React.FC<MembershipDetailsProps> = ({
             </Text>
           </View>
 
-          {/* Next Renewal */}
-          <View style={styles.detailRow}>
-            <Text style={styles.detailLabel}>Next Renewal:</Text>
-            <Text style={styles.detailValue}>
-              {formatDate(membership.renewal_date)}
-            </Text>
-          </View>
+          {/* Next Payment Date */}
+          {membership.next_payment_date && (
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>Next Payment Date:</Text>
+              <Text style={styles.detailValue}>
+                {formatDate(membership.next_payment_date)}
+              </Text>
+            </View>
+          )}
 
           {/* Status */}
           <View style={styles.detailRow}>
@@ -487,12 +492,6 @@ const styles = StyleSheet.create({
   },
   detailSection: {
     marginTop: 20,
-  },
-  sectionTitle: {
-    color: "#FFFFFF",
-    fontSize: 18,
-    fontWeight: "600",
-    marginBottom: 12,
   },
   detailText: {
     color: "#CCCCCC",

--- a/types/user.ts
+++ b/types/user.ts
@@ -7,6 +7,7 @@ export interface MembershipInfo {
   plan_name: string
   start_date: string
   renewal_date: string
+  next_payment_date?: string | null
 }
 
 export interface MembershipState {


### PR DESCRIPTION
# :clipboard: Title
Display next payment date on membership page

---

# :sparkles: Changes Made
- Added `next_payment_date` field to `MembershipInfo` and `MembershipData` interfaces
- Updated main membership card to display "Next Payment Date" instead of "Next Renewal"
- Updated membership details modal to show "Next Payment Date"
- Implemented conditional rendering - field only displays when `next_payment_date` is present
- Removed fallback to `renewal_date` as per requirements
- Fixed duplicate style key (`sectionTitle`) lint error

---

# :brain: Reason for Changes
The backend API endpoint `/secure/customers/membership` has been updated to provide a more accurate `next_payment_date` field calculated from Stripe data. This field is only present for newer accounts with active Stripe subscriptions. For older accounts, this field will be missing or null in the API response.

This change ensures the mobile app displays the correct payment date for users, improving transparency and accuracy of billing information.

---

# :test_tube: Testing Performed
- [x] Mobile App tested - conditional rendering verified
- [x] No console errors (Frontend)
- [x] Lint checks passed
- [x] Verified `next_payment_date` displays correctly when present
- [x] Verified field is hidden when `next_payment_date` is null/undefined
- [x] Date formatting verified (e.g., "October 22, 2025")

---

# :link: Related Task
Implements requirements from `tmpDocs/TODO.250929.md`

---

# Notes for Reviewer
- The change follows minimal modification principle - only necessary files were updated
- No new dependencies introduced
- Maintains backward compatibility - older accounts without `next_payment_date` will simply not show the field
- Error handling for date parsing already exists in `formatDate()` function