### PR TITLE
[Bugfix] Disable membership test mode by default for production

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -3,7 +3,7 @@
 
 // Membership test mode flags (read from Expo public env variables)
 export const USE_MEMBERSHIP_TEST_MODE: boolean =
-  (process.env.EXPO_PUBLIC_MEMBERSHIP_TEST_MODE ?? "true").toLowerCase() ===
+  (process.env.EXPO_PUBLIC_MEMBERSHIP_TEST_MODE ?? "false").toLowerCase() ===
   "true";
 
 // Default to the only valid plan ID provided by backend until fixed


### PR DESCRIPTION
# :clipboard: Title
[Bugfix] Disable membership test mode by default for production

---

# :sparkles: Changes Made
- Changed `USE_MEMBERSHIP_TEST_MODE` default value from `"true"` to `"false"` in `utils/constants.ts`
- This ensures production users purchase actual membership plans instead of the hardcoded test plan
- Test mode can still be explicitly enabled via `EXPO_PUBLIC_MEMBERSHIP_TEST_MODE=true` environment variable when needed

---

# :brain: Reason for Changes
**Critical Production Issue**: All membership purchases were incorrectly using the same test plan ID (`14a89cfc-518f-4871-84fe-43d27e2fe274`) regardless of which plan users selected.

**Impact**:
- Users selecting Premium/Elite plans were being charged for/receiving test plan benefits
- Backend records showed incorrect membership types
- Potential revenue loss and user confusion

**Root Cause**: The `USE_MEMBERSHIP_TEST_MODE` constant was hardcoded with default value `"true"`, which was intended for development/testing but was never changed before production deployment.

---

# :test_tube: Testing Performed
- [x] Code review - verified change affects only the default value in constants.ts
- [x] Impact analysis - confirmed only `purchaseMembershipPlan()` function uses this flag
- [x] Backward compatibility - existing code structure unchanged
- [ ] Mobile App tested via Expo - pending deployment verification
- [ ] Production monitoring - will verify correct plan IDs are used post-deployment

**Test Plan**:
1. Verify network requests show correct `planId` in URL (not hardcoded test ID)
2. Confirm payment amounts match selected plans
3. Validate backend records correct membership types

---

# :link: Related Issue
Fixes membership purchase flow where all plans were redirected to test plan ID.

**App Store Status**: App is currently live on App Store, making this a high-priority production hotfix.

---

# Notes for Reviewer
**High Priority**: This is a production hotfix that should be deployed ASAP.

**Risk Assessment**: 
- **Low technical risk** - Single constant default value change
- **High business impact** - Fixes potential revenue loss and user confusion
- **No breaking changes** - Fully backward compatible

**Verification Steps**:
1. Check that modification is limited to `utils/constants.ts:6` (one line change)
2. Confirm default changes from `"true"` to `"false"`
3. After merge, monitor production metrics for correct plan distribution

**Environment Variable Override**:
To enable test mode in development, set:
```bash
EXPO_PUBLIC_MEMBERSHIP_TEST_MODE=true
```