### PR TITLE
[Bugfix] Clear membership cache in central logout function

### DIFF
--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -15,6 +15,7 @@ import type { RootState } from "@/store"
 import { setUser as setReduxUser, logout as reduxLogout } from "@/store/slices/userSlice"
 import { clearPractices } from "@/store/slices/practicesSlice"
 import { clearMatches } from "@/store/slices/gamesSlice"
+import { clearMembership } from "@/store/slices/membershipSlice"
 import { persistor } from "@/store"
 
 type User = {
@@ -565,6 +566,7 @@ export const useAuth = () => {
       dispatch(reduxLogout())           // Clear user data
       dispatch(clearPractices())        // Clear practices cache
       dispatch(clearMatches())          // Clear match history cache
+      dispatch(clearMembership())       // Clear membership cache
       
       // 🔄 Now purge the persisted data
       await persistor.purge()


### PR DESCRIPTION
# :clipboard: Title
Clear membership cache in central logout function

---

# :sparkles: Changes Made

- **Import clearMembership action**: Added import from `membershipSlice` to auth utils
- **Dispatch clearMembership on logout**: Added `dispatch(clearMembership())` in the central logout function alongside existing cache clear actions
- **Centralized state cleanup**: Ensures all user-specific Redux slices are cleared during logout

---

# :brain: Reason for Changes

**Root Cause**: The previous fix (PR #38) attempted to solve the ghost membership issue by clearing the cache when the membership screen loads. However, this approach is not fully reliable and can fail under race conditions where:
- Cached data loads faster than the API call
- Component mounts before Redux persist has finished rehydrating
- User navigates quickly between screens

**Definitive Solution**: The true root cause is that the central `logout` function in `utils/auth.ts` does not clear the `membership` slice from Redux store. While it clears user authentication, practices, and matches, it fails to clear membership data. This leaves stale data in persisted local storage that can be incorrectly loaded by the next user.

**Why This Fix is Better**:
- ✅ **Single Source of Truth**: Fixes the issue at the central logout point
- ✅ **Guaranteed Execution**: Runs before any Redux persist operations
- ✅ **No Race Conditions**: Clears state synchronously during logout flow
- ✅ **Follows Existing Pattern**: Uses the same pattern as `clearPractices()` and `clearMatches()`
- ✅ **Minimal Change**: Only 2 lines added (import + dispatch)

---

# :test_tube: Testing Performed

- [x] Mobile App tested via Expo / emulator
- [x] Verified membership cache is cleared during logout
- [x] No ghost membership appears across user sessions
- [x] Tested logout → login with different user roles
- [x] Verified no console errors during logout flow

**Manual Test Steps**:
1. Log in as user with membership (e.g., brandon@challengeindustries.ca)
2. Navigate to membership screen and verify membership data displays
3. Log out
4. Log in as user without membership (e.g., mostapha@gmail.com)
5. Navigate to membership screen
6. ✅ Verify no ghost membership appears
7. ✅ Verify "Available Membership Plans" section shows correctly

---

# :link: Related Issues

**Previous PR**: #38 - Initial fix attempt (screen-level cache clearing)

**Technical Documentation**:
- `tmpDocs/FIX.251008.02.md` - Definitive fix specification
- `tmpDocs/BUG.251008.01.503_ERROR_ANALYSIS.md` - Root cause analysis

---

# Notes for Reviewer

**Key Insight**: This fix complements PR #38 rather than replacing it. Both fixes work together:
- **This PR (logout fix)**: Prevents stale data from persisting across sessions (primary fix)
- **PR #38 (screen fix)**: Handles edge cases and 503 errors gracefully (defensive programming)

**Files Changed**:
- `utils/auth.ts` - Added 2 lines (import + dispatch)

**Why Minimal Impact**:
- Follows exact same pattern as existing `clearPractices()` and `clearMatches()`
- No new dependencies or complexity
- No changes to component logic or UI behavior

**Verification Command**:
```bash
# After logout, Redux persist storage should be completely empty
# No membership data should remain in AsyncStorage
```