### PR TITLE
[Chore] Update pricing display and temporarily hide player stats

### DIFF
--- a/app/(athlete)/(tabs)/profile.tsx
+++ b/app/(athlete)/(tabs)/profile.tsx
@@ -107,15 +107,16 @@ const AthleteProfileScreen = () => {
           teamLogo={images.teamLogo}
         />
 
-        {/* Player Stats */}
+        {/* Player Stats (Temporarily Hidden) */}
+        {/*
         <View className="mt-6">
         <PlayerStatsCard
         overallRating={user?.overallRating ?? 0}
         pointsPerGame={user?.pointsPerGame ?? 0}
         assistsPerGame={user?.assistsPerGame ?? 0}
-/>
-
+        />
         </View>
+        */}
 
 
         {/* My Account Section */}

--- a/components/membership/MembershipPurchaseList.tsx
+++ b/components/membership/MembershipPurchaseList.tsx
@@ -315,7 +315,7 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
             <Text style={styles.priceText}>
               {item.price ? (typeof item.price === 'number' ? `$${item.price.toFixed(2)}` : item.price.toString().replace(/\$\$/g, '$')) : "Price not available"}
             </Text>
-            {item.price && <Text style={styles.priceNote}>per month</Text>}
+            {item.price && <Text style={styles.priceNote}>bi-weekly</Text>}
           </View>
         </View>
 


### PR DESCRIPTION
# :clipboard: Title
Update pricing display and temporarily hide player stats

---

# :sparkles: Changes Made

- **Updated membership billing cycle text**: Changed from "per month" to "bi-weekly" in membership plan cards
- **Temporarily hidden Player Stats section**: Commented out the PlayerStatsCard component on athlete profile screen for easy restoration later
- **Code preservation**: Player Stats section code is commented out (not deleted) to allow quick restoration when needed

---

# :brain: Reason for Changes

**Pricing Display Update**: The membership billing cycle needs to reflect the actual bi-weekly payment schedule rather than monthly, providing accurate pricing information to users.

**Player Stats Temporary Hide**: The Player Stats feature is being temporarily hidden from the athlete profile while backend data integration is being finalized. The code is preserved via comments for quick restoration.

**Minimal Impact**: Both changes are small, targeted UI updates that don't affect business logic or data flow.

---

# :test_tube: Testing Performed

- [x] Mobile App tested via Expo / emulator
- [x] Verified membership pricing shows "bi-weekly" text correctly
- [x] Verified Player Stats section is hidden on athlete profile
- [x] Verified profile layout displays correctly without Player Stats
- [x] No console errors (Frontend)
- [x] Mobile app builds successfully

---

# :link: Related Documentation

**Technical Specification**: `tmp/Prompt.251009.03.md`

---

# Notes for Reviewer

**Files Changed**:
1. `components/membership/MembershipPurchaseList.tsx` - Line 318: Updated billing cycle text
2. `app/(athlete)/(tabs)/profile.tsx` - Lines 110-119: Commented out Player Stats section

**Easy Restoration**: To restore Player Stats section, simply uncomment lines 111-119 in `profile.tsx`.

**Visual Changes**:
- Membership cards now display "$XX.XX bi-weekly" instead of "$XX.XX per month"
- Athlete profile no longer shows the Player Stats card section

**No Breaking Changes**: These are purely UI display changes with no impact on backend APIs or data structures.