### PR TITLE
[Bugfix] Prevent double booking in practice scheduling

### DIFF
--- a/app/(coach)/screens/coach-booking/practiceBooking.tsx
+++ b/app/(coach)/screens/coach-booking/practiceBooking.tsx
@@ -94,6 +94,7 @@ const CoachPracticeBooking = () => {
   const [formErrors, setFormErrors] = useState<{[key: string]: string}>({})
 
   const user = useSelector(selectCurrentUser)
+  const isBooking = useSelector((state: RootState) => state.practices.isBooking)
 
   const coachTeams = useSelector((state: RootState) =>
     user?.id ? selectTeamsForCoach(state, user.id) : [],
@@ -211,6 +212,11 @@ const formatTeamForDisplay = (team: Team) => ({
 
   
 const handleConfirmBooking = async () => {
+  // Prevent double booking - check if a booking request is already in progress
+  if (isBooking) {
+    return
+  }
+
   if (!selectedTeam) {
     Alert.alert("Missing Info", "Please select a team.")
     return
@@ -557,7 +563,7 @@ const handleConfirmBooking = async () => {
           `Repeats ${recurringOptions.weekly ? 'weekly' : recurringOptions.biweekly ? 'biweekly' : 'monthly'} for ${recurringOptions.occurrences} occurrences` :
           undefined
         }
-        isSubmitting={isSubmitting}
+        isSubmitting={isBooking || isSubmitting}
       />
     </SafeAreaView>
   )

--- a/store/slices/practicesSlice.ts
+++ b/store/slices/practicesSlice.ts
@@ -15,6 +15,7 @@ const initialState: PracticesState = {
   status: "idle",
   error: null,
   lastFetched: null,
+  isBooking: false, // Initialize booking flag
 }
 
 // Helper function to extract title
@@ -288,6 +289,26 @@ const practicesSlice = createSlice({
       .addCase(fetchPractices.rejected, (state, action) => {
         state.status = "failed"
         state.error = action.payload as string
+      })
+      // Handle createPracticeThunk booking state
+      .addCase(createPracticeThunk.pending, (state) => {
+        state.isBooking = true
+      })
+      .addCase(createPracticeThunk.fulfilled, (state) => {
+        state.isBooking = false
+      })
+      .addCase(createPracticeThunk.rejected, (state) => {
+        state.isBooking = false
+      })
+      // Handle createRecurringPracticeThunk booking state
+      .addCase(createRecurringPracticeThunk.pending, (state) => {
+        state.isBooking = true
+      })
+      .addCase(createRecurringPracticeThunk.fulfilled, (state) => {
+        state.isBooking = false
+      })
+      .addCase(createRecurringPracticeThunk.rejected, (state) => {
+        state.isBooking = false
       })
   },
 })

--- a/types/practice.ts
+++ b/types/practice.ts
@@ -7,6 +7,7 @@ export interface PracticesState {
   status: "idle" | "loading" | "succeeded" | "failed"
   error: string | null
   lastFetched: string | null
+  isBooking: boolean // Flag to prevent double booking
 }
 
 export interface CreatePracticePayload {


### PR DESCRIPTION
# :clipboard: Title
[Bugfix] Prevent double booking in practice scheduling

---

# :sparkles: Changes Made
- Added `isBooking` flag to `PracticesState` interface to track booking request status
- Updated `practicesSlice` extraReducers to manage `isBooking` state during thunk lifecycle:
  - Set `isBooking=true` when practice creation starts (pending state)
  - Set `isBooking=false` when practice creation completes or fails (fulfilled/rejected states)
- Added early return check in `handleConfirmBooking()` to prevent execution if booking is already in progress
- Updated `ConfirmationModal` component to disable submit button when `isBooking || isSubmitting` is true

---

# :brain: Reason for Changes
**Problem**: Users could create duplicate practice bookings when:
- Network latency caused delayed API responses
- Users rapidly clicked the confirm button multiple times
- The local `isSubmitting` state alone wasn't sufficient to prevent race conditions

**Solution**: Implemented dual-layer protection:
1. **Local state** (`isSubmitting`): Provides immediate UI feedback
2. **Redux state** (`isBooking`): Synchronizes with Redux thunk execution lifecycle for reliable state tracking

This client-side solution effectively prevents duplicate API calls without requiring backend modifications.

---

# :test_tube: Testing Performed
- [x] Mobile App tested via Expo / emulator
- [x] No console errors (Frontend)
- [x] Mobile app builds successfully
- [ ] Backend APIs tested via Postman (not required - client-side fix)

**Test Scenarios**:
1. ✅ Rapid consecutive button clicks - Only one booking created
2. ✅ Network delay simulation - Button remains disabled, single request sent
3. ✅ Normal single practice booking - Works as expected
4. ✅ Normal recurring practice booking - Works as expected
5. ✅ Error handling - `isBooking` correctly resets on failure

---

# Screenshots or Screen Recording (Optional)
_Testing can be performed by attempting rapid clicks on the confirmation button in the practice booking flow._

---

# :link: Related Trello Task
<!-- Link to the related Trello card if available -->

---

# Notes for Reviewer
**Key Changes**:
- Only 3 files modified (`types/practice.ts`, `store/slices/practicesSlice.ts`, `practiceBooking.tsx`)
- No new dependencies added
- No breaking changes to existing functionality
- Follows minimal change principle with maximum code reuse

**Review Focus**:
- Verify `isBooking` state management in `extraReducers`
- Confirm early return logic in `handleConfirmBooking()`
- Check that both `createPracticeThunk` and `createRecurringPracticeThunk` are covered

**Deployment Notes**:
- Safe to deploy immediately - no backend changes required
- No migration scripts needed
- Backward compatible with existing practice booking data