### PR TITLE
[Feature] Add team logo display next to country flag in athlete profile

### DIFF
--- a/app/(athlete)/(tabs)/profile.tsx
+++ b/app/(athlete)/(tabs)/profile.tsx
@@ -26,6 +26,11 @@ type User = {
   overallRating?: number;
   pointsPerGame?: number;
   assistsPerGame?: number;
+  team?: {
+    id?: string;
+    name?: string;
+    logo?: string;
+  };
 };
 
 const AthleteProfileScreen = () => {
@@ -104,7 +109,7 @@ const AthleteProfileScreen = () => {
           role={user.role}
           profileImage={user.profileImage ? { uri: user.profileImage } : images.headshot}
           countryCode={user?.countryCode } // ✅ Ensure countryCode is always defined
-          teamLogo={images.teamLogo}
+          teamLogo={user?.team?.logo} // ✅ Display team logo from user data
         />
 
         {/* Player Stats (Temporarily Hidden) */}

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -24,15 +24,16 @@ const ProfileHeader = ({
     <View className="w-full px-4 mt-10">
       <View className="bg-gold-100 h-60 rounded-3xl overflow-hidden relative flex px-4 items-center">
         
-        {/* Country Flag or Team Logo */}
+        {/* Country Flag and Team Logo */}
         <View className="absolute top-4 left-4 flex flex-row items-center">
-          {countryCode ? (
+          {countryCode && (
             <View className="w-10 h-10 rounded-full overflow-hidden border-2 border-white shadow-md">
               <Flag isoCode={countryCode} size={40} style={{ width: "100%", height: "100%" }} />
             </View>
-          ) : teamLogo ? (
-            <Image source={teamLogo} className="w-10 h-10" style={{ resizeMode: "contain" }} />
-          ) : null}
+          )}
+          {teamLogo && (
+            <Image source={{ uri: teamLogo }} className="w-10 h-10 ml-2 rounded-full border-2 border-white shadow-md" style={{ resizeMode: "contain" }} />
+          )}
         </View>
 
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -34,6 +34,11 @@ export interface User {
   position?: string
   bio?: string
   teamLogo?: string
+  team?: {
+    id?: string
+    name?: string
+    logo?: string
+  }
   // Backend API properties (snake_case) - for compatibility
   first_name?: string
   last_name?: string

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -71,6 +71,14 @@ export const loginUser = async (email: string, password: string): Promise<User> 
     const jwtToken = authHeader?.replace("Bearer ", "") || "";
 
 
+    // ✅ Map team data from athlete_info if available
+    const athleteInfo = (response.data as any).athlete_info;
+    const teamData = athleteInfo?.team_logo ? {
+      id: athleteInfo.team_id,
+      logo: athleteInfo.team_logo,
+      // Note: Backend does not provide team_name, so name will be undefined
+    } : undefined;
+
     // ✅ Return UUID from backend response as `id`
     return {
       id: (response.data as any).id,
@@ -83,6 +91,7 @@ export const loginUser = async (email: string, password: string): Promise<User> 
       token: jwtToken, // ✅ Now this is set correctly!
       firebaseId: firebaseUser.uid,
       profileImage: (response.data as any).photo_url || "", // ✅ Include profile image from backend
+      team: teamData, // ✅ Include team data from athlete_info if available
     };
 
   } catch (error: any) {

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -73,9 +73,9 @@ export const loginUser = async (email: string, password: string): Promise<User> 
 
     // ✅ Map team data from athlete_info if available
     const athleteInfo = (response.data as any).athlete_info;
-    const teamData = athleteInfo?.team_logo ? {
+    const teamData = athleteInfo?.team_logo_url ? {
       id: athleteInfo.team_id,
-      logo: athleteInfo.team_logo,
+      logo: athleteInfo.team_logo_url,
       // Note: Backend does not provide team_name, so name will be undefined
     } : undefined;
 


### PR DESCRIPTION
# :clipboard: Title
Add team logo display next to country flag in athlete profile header

---

# :sparkles: Changes Made
- Added `team` field to User interface in `types/user.ts` with optional id, name, and logo properties
- Updated `loginUser()` in `utils/api.ts` to map team data from backend `/auth` endpoint's `athlete_info.team_logo_url` and `athlete_info.team_id`
- Modified `app/(athlete)/(tabs)/profile.tsx` to pass team logo to ProfileHeader component
- Updated `components/profile/ProfileHeader.tsx` to display both country flag AND team logo simultaneously (changed from "or" to "and" logic)
- Fixed field name mismatch: backend returns `team_logo_url` not `team_logo`

**Commits:**
- `44c0677` - feat: add team logo display next to country flag in athlete profile
- `50ee4d5` - fix: correct field name from team_logo to team_logo_url

---

# :brain: Reason for Changes
Athletes need to see their team logo displayed alongside their country flag in the profile header for better team identification and visual representation. The backend team added `team_id` and `team_logo_url` fields to the `/auth` endpoint's `athlete_info` object specifically for this feature.

**Implementation approach:** Solution 1 (Backend modification with minimal changes) - wait for backend to add team fields, then map the data during login flow.

---

# :test_tube: Testing Performed
- [x] Backend `/auth` endpoint verified to return `team_id` and `team_logo_url` fields
- [x] Python verification script confirms all required fields present
- [x] Backend deployment successful
- [ ] Mobile app tested with athlete account (appleathlete@test.com)
- [ ] Team logo displays correctly next to country flag in profile header
- [ ] No console errors
- [ ] App builds successfully

**Backend Verification Results:**
```
✅ athlete_info exists
✅ team_id exists: 33f838b9-435f-4088-b0ca-90246225035d
✅ team_logo_url exists: data:image/png;base64,iVBOR...
✅ ALL REQUIRED FIELDS PRESENT
```

---

# :link: Related Documentation
- Implementation plan: `tmp/prompt.250120.01.md`
- Test account: `appleathlete@test.com` / `AppleTest1`

---

# Notes for Reviewer
1. **Field name correction:** Initial implementation used `team_logo` but backend actually returns `team_logo_url`. This has been fixed in commit 50ee4d5.

2. **Display logic change:** ProfileHeader now shows BOTH country flag and team logo side-by-side (was either/or before). Both images are 40x40 rounded with white border.

3. **Data flow:** Team data is fetched during login from `/auth` endpoint, stored in Redux user state, and displayed in profile header.

4. **Minimal changes principle:** Only 4 files modified, no new dependencies, maximum code reuse achieved.

5. **Manual testing needed:** Please test with athlete account to verify team logo displays correctly in profile header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)