### PR TITLE
[UI] Add consistent refresh icon across pages

### DIFF
--- a/app/(athlete)/(tabs)/calendar.tsx
+++ b/app/(athlete)/(tabs)/calendar.tsx
@@ -2,5 +2,5 @@
 import SharedCalendar from "@/components/shared/SharedCalendar"
 
 export default function AthleteCalendar() {
-  return <SharedCalendar userRole="athlete" title="Calendar" subtitle="Refresh" />
+  return <SharedCalendar userRole="athlete" title="Calendar" />
 }

--- a/app/(athlete)/(tabs)/matches.tsx
+++ b/app/(athlete)/(tabs)/matches.tsx
@@ -8,13 +8,12 @@ import dayjs from "dayjs"
 import { SafeAreaView } from "react-native-safe-area-context"
 import MatchCard from "../../../components/events/MatchCard"
 import { StatusBar } from "expo-status-bar"
-import { FontAwesome6 } from "@expo/vector-icons"
 import { useAppDispatch, useAppSelector } from "../../../store/hooks"
 import { fetchMatches, clearMatches } from "../../../store/slices/gamesSlice"
 import LoadingIndicator from "../../../components/feedback/LoadingIndicator"
 import EmptyState from "../../../components/feedback/EmptyState"
+import PageTitle from "@/components/PageTitle"
 import { useAuth } from "@/utils/auth"
-import Constants from "expo-constants"
 
 const { width } = Dimensions.get("window")
 
@@ -186,24 +185,22 @@ const MatchesScreen: React.FC = () => {
 
       <View className="flex-1">
         {/* Header */}
-        <View className="px-6 pb-4 border-b border-white-100/10 flex-row justify-between items-center">
-          <Text className="text-white-100 text-3xl font-bold">Matches</Text>
-          <TouchableOpacity
-            onPress={() => {
-              fetchInteractionRef.current?.cancel()
-              fetchInteractionRef.current = InteractionManager.runAfterInteractions(async () => {
-                const authToken = await getAuthToken()
+        <PageTitle
+          title="Matches"
+          showRefreshIcon
+          isRefreshing={status === "loading"}
+          onButtonPress={() => {
+            fetchInteractionRef.current?.cancel()
+            fetchInteractionRef.current = InteractionManager.runAfterInteractions(async () => {
+              const authToken = await getAuthToken()
 
-                if (authToken) {
-                  dispatch(clearMatches())
-                  dispatch(fetchMatches(authToken))
-                }
-              })
-            }}
-          >
-            <Text className="text-gold-100 font-semibold">Refresh</Text>
-          </TouchableOpacity>
-        </View>
+              if (authToken) {
+                dispatch(clearMatches())
+                dispatch(fetchMatches(authToken))
+              }
+            })
+          }}
+        />
 
         {/* Horizontal Calendar */}
         <FlatList

--- a/app/(coach)/(tabs)/coachCalendar.tsx
+++ b/app/(coach)/(tabs)/coachCalendar.tsx
@@ -1,8 +1,8 @@
-// app/(athlete)/(tabs)/calendar.tsx
+// app/(coach)/(tabs)/coachCalendar.tsx
 import SharedCalendar from "@/components/shared/SharedCalendar"
 
 export default function CoachCalendar() {
-  return <SharedCalendar userRole="coach" title="Calendar" subtitle="Refresh" />
+  return <SharedCalendar userRole="coach" title="Calendar" />
 }
 
   

--- a/app/(coach)/(tabs)/coachMatches.tsx
+++ b/app/(coach)/(tabs)/coachMatches.tsx
@@ -259,37 +259,31 @@ const CoachMatches: React.FC = () => {
 
       <Animated.View style={{ opacity: fadeAnim }} className="flex-1">
         {/* Header */}
-        <View className="px-6 pb-4 border-b border-white-100/10 flex-row justify-between items-center">
-          <Text className="text-white-100 text-3xl font-bold">Matches</Text>
+        <View className="px-5 pb-3 border-b border-white-100/10 flex-row justify-between items-center">
+          <Text className="text-white-100 text-3xl font-extrabold">Matches</Text>
           <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
             <TouchableOpacity style={styles.createButton} onPress={openCreateGameModal}>
               <Ionicons name="add" size={20} color="#000" />
               <Text style={styles.createButtonText}>Create</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              onPress={async () => {
-                const authToken = await getAuthToken();
-                if (!authToken) return;
+              onPress={() => {
+                fetchInteractionRef.current?.cancel();
+                fetchInteractionRef.current = InteractionManager.runAfterInteractions(async () => {
+                  const authToken = await getAuthToken();
+                  if (!authToken) return;
 
-                dispatch(clearMatches());
-                dispatch(fetchMatches(authToken));
+                  dispatch(clearMatches());
+                  dispatch(fetchMatches(authToken));
+                });
               }}
+              disabled={status === "loading"}
             >
-              <Text
-                className="text-gold-100 font-semibold"
-                onPress={() => {
-                  fetchInteractionRef.current?.cancel();
-                  fetchInteractionRef.current = InteractionManager.runAfterInteractions(async () => {
-                    const authToken = await getAuthToken();
-                    if (!authToken) return;
-
-                    dispatch(clearMatches());
-                    dispatch(fetchMatches(authToken));
-                  });
-                }}
-              >
-                Refresh
-              </Text>
+              <Ionicons
+                name="refresh"
+                size={24}
+                color={status === "loading" ? "#AAAAAA" : "#FFD700"}
+              />
             </TouchableOpacity>
           </View>
         </View>

--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -1,17 +1,28 @@
 import type React from "react"
 import { View, Text, TouchableOpacity } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
 
 interface PageTitleProps {
   title: string
   subtitle?: string
   align?: "left" | "center" | "right"
   onButtonPress?: () => void
+  showRefreshIcon?: boolean
+  isRefreshing?: boolean
 }
 
-const PageTitle: React.FC<PageTitleProps> = ({ title, subtitle, align = "left", onButtonPress }) => (
+const PageTitle: React.FC<PageTitleProps> = ({ title, subtitle, align = "left", onButtonPress, showRefreshIcon = false, isRefreshing = false }) => (
   <View className="px-5 pb-3 border-b border-white-100/10 flex-row items-center justify-between">
     <Text className="text-white-100 text-3xl font-extrabold">{title}</Text>
-    {subtitle && (
+    {showRefreshIcon && onButtonPress ? (
+      <TouchableOpacity onPress={onButtonPress} disabled={isRefreshing} activeOpacity={0.7}>
+        <Ionicons
+          name="refresh"
+          size={24}
+          color={isRefreshing ? "#AAAAAA" : "#FFD700"}
+        />
+      </TouchableOpacity>
+    ) : subtitle && (
       <TouchableOpacity onPress={onButtonPress} disabled={!onButtonPress} activeOpacity={onButtonPress ? 0.7 : 1}>
         <Text className={`text-gray-400 text-base ${onButtonPress ? "underline" : ""}`}>{subtitle}</Text>
       </TouchableOpacity>

--- a/components/shared/SharedCalendar.tsx
+++ b/components/shared/SharedCalendar.tsx
@@ -23,7 +23,6 @@ import Constants from "expo-constants"
 interface SharedCalendarProps {
   userRole: "athlete" | "coach" | "instructor" | "parent"
   title?: string
-  subtitle?: string
   childrenData?: any[]
 }
 
@@ -41,7 +40,6 @@ interface CalendarEvent {
 const SharedCalendar: React.FC<SharedCalendarProps> = ({
   userRole,
   title = "Calendar",
-  subtitle,
   childrenData = [],
 }) => {
   const [selectedDate, setSelectedDate] = useState<string>(dayjs().format("YYYY-MM-DD"))
@@ -324,7 +322,7 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
       <StatusBar translucent style="light" />
 
       <Animated.View style={{ flex: 1, opacity: fadeAnim }}>
-        <PageTitle title={title} subtitle={subtitle} onButtonPress={subtitle ? handleRefresh : undefined} />
+        <PageTitle title={title} onButtonPress={handleRefresh} showRefreshIcon isRefreshing={isLoading} />
 
         <View className="px-5 py-2">
           <CalendarCard

--- a/store/slices/scheduleSlice.ts
+++ b/store/slices/scheduleSlice.ts
@@ -41,11 +41,9 @@ const initialState: ScheduleState = {
 // Fetch schedule data from /secure/schedule endpoint
 export const fetchSchedule = createAsyncThunk("schedule/fetchSchedule", async (token: string, { rejectWithValue }) => {
   try {
-
     const response = await axios.get(`${API_URL}/secure/schedule`, {
       headers: { Authorization: `Bearer ${token}` },
     })
-
 
     const responseData = response.data
     


### PR DESCRIPTION
- Update PageTitle component to support showRefreshIcon and isRefreshing props
- Replace "Refresh" text with refresh icon on Calendar page (athlete & coach)
- Replace "Refresh" text with refresh icon on Matches page (athlete & coach)
- Icon shows golden color when active, gray when loading
- Matches the existing refresh icon style on Courts page

