### PR TITLE
[Bugfix] Event registration button logic and date parsing

### DIFF
--- a/app/screens/event-details/[id].tsx
+++ b/app/screens/event-details/[id].tsx
@@ -127,6 +127,7 @@ const EventDetails: React.FC = () => {
   const [isCheckingPayment, setIsCheckingPayment] = useState(false)
   const [enrollmentOptions, setEnrollmentOptions] = useState<any>(null)
   const [loadingEnrollmentOptions, setLoadingEnrollmentOptions] = useState(false)
+  const [enrollmentOptionsLoaded, setEnrollmentOptionsLoaded] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [membershipLoaded, setMembershipLoaded] = useState(false)
   const fadeAnim = useRef(new Animated.Value(0)).current
@@ -218,13 +219,15 @@ const EventDetails: React.FC = () => {
       if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEnrollmentOptions: API call completed - ${apiDuration}ms`)
 
       setEnrollmentOptions(options)
+      setEnrollmentOptionsLoaded(true)
 
       const totalDuration = Date.now() - startTime
-      if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEnrollmentOptions: Completed - ${totalDuration}ms total`)
+      if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEnrollmentOptions: Completed - ${totalDuration}ms total`, options)
     } catch (error) {
       const totalDuration = Date.now() - startTime
       if (__DEV__) console.warn(`❌ [Event ${id}] fetchEnrollmentOptions: Error after ${totalDuration}ms`, error)
       setEnrollmentOptions(null)
+      setEnrollmentOptionsLoaded(true) // Mark as loaded even on error so we know we tried
     } finally {
       setLoadingEnrollmentOptions(false)
     }
@@ -626,6 +629,11 @@ const EventDetails: React.FC = () => {
       })
 
       setRegistered(isUserEnrolled)
+
+      // Fetch enrollment options to determine if registration is available (for non-practice events)
+      if (!processedEvent.title.toLowerCase().includes('practice')) {
+        fetchEnrollmentOptions(cleanedId)
+      }
 
       const totalDuration = Date.now() - startTime
       if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEventDetails: Completed successfully - ${totalDuration}ms total`)
@@ -1126,7 +1134,15 @@ const EventDetails: React.FC = () => {
             <FontAwesome5 name="share-alt" size={22} color={COLORS.primary} />
           </TouchableOpacity>
 
-          {!event.title.toLowerCase().includes('practice') && (
+          {/* Only show register button if:
+              1. Not a practice
+              2. Enrollment options loaded
+              3. Registration is available (can_enroll_free OR credit_cost > 0 OR stripe_price_id OR membership_plan_id)
+          */}
+          {!event.title.toLowerCase().includes('practice') &&
+           enrollmentOptionsLoaded &&
+           enrollmentOptions &&
+           (enrollmentOptions.can_enroll_free || enrollmentOptions.credit_cost > 0 || enrollmentOptions.stripe_price_id || enrollmentOptions.membership_plan_id) && (
             <TouchableOpacity
               style={[styles.registerButton, registered && styles.registeredButton, isPastEvent && styles.disabledButton]}
               onPress={handleRegister}

--- a/store/slices/eventsSlice.ts
+++ b/store/slices/eventsSlice.ts
@@ -63,7 +63,24 @@ const parseApiDateFormat = (dateString: string): { date: string; time: string } 
   if (!dateString) return { date: dayjs().format("YYYY-MM-DD"), time: "TBD" }
 
   try {
-    const [datePart, timePart] = dateString.split(" ")
+    // Handle both formats: "2025-11-27 14:30:00" (space) and "2025-11-27T14:30:00" (ISO)
+    let datePart: string
+    let timePart: string
+
+    if (dateString.includes("T")) {
+      // ISO format: "2025-11-27T14:30:00Z" or "2025-11-27T14:30:00"
+      [datePart, timePart] = dateString.split("T")
+      timePart = timePart.split("Z")[0] // Remove Z if present
+    } else if (dateString.includes(" ")) {
+      // Space format: "2025-11-27 14:30:00 -0700"
+      const parts = dateString.split(" ")
+      datePart = parts[0]
+      timePart = parts[1]
+    } else {
+      // Just a date, no time
+      return { date: dayjs(dateString).format("YYYY-MM-DD"), time: "TBD" }
+    }
+
     const formattedDate = dayjs(datePart).format("YYYY-MM-DD")
     const [hour, minute] = timePart.split(":")
     const hourNum = parseInt(hour, 10)

--- a/store/slices/scheduleSlice.ts
+++ b/store/slices/scheduleSlice.ts
@@ -120,7 +120,7 @@ export const fetchSchedule = createAsyncThunk("schedule/fetchSchedule", async (t
         })
       })
     }
-    
+
     // Process practices
     if (responseData.practices && Array.isArray(responseData.practices)) {
       responseData.practices.forEach((practice: any) => {


### PR DESCRIPTION
Event Registration:
- Only show register button when enrollment options are available
- Fetch enrollment options when event loads (for non-practice events)
- Check for can_enroll_free, credit_cost, stripe_price_id, or membership_plan_id
- Button hidden when event doesn't require/allow registration

Event Date Parsing:
- Fix parseApiDateFormat to handle multiple date formats
- Support ISO format: "2025-11-27T14:30:00Z"
- Support space format: "2025-11-27 14:30:00 -0700"
- Support date-only format: "2025-11-27"
- Event tiles now correctly display date and time

