### PR TITLE
[Feature] Add registration_required check to event registration button

### DIFF
--- a/app/screens/event-details/[id].tsx
+++ b/app/screens/event-details/[id].tsx
@@ -78,6 +78,7 @@ interface ApiEventResponse {
   start_at?: string
   end_at?: string
   capacity?: number
+  registration_required?: boolean // Whether registration is required/allowed for this event
   // Practice-specific fields from /secure/events endpoint
   program?: {
     id: string
@@ -130,6 +131,7 @@ const EventDetails: React.FC = () => {
   const [enrollmentOptionsLoaded, setEnrollmentOptionsLoaded] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [membershipLoaded, setMembershipLoaded] = useState(false)
+  const [registrationRequired, setRegistrationRequired] = useState<boolean | null>(null)
   const fadeAnim = useRef(new Animated.Value(0)).current
   const slideAnim = useRef(new Animated.Value(50)).current
   const paymentCheckInterval = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -482,6 +484,8 @@ const EventDetails: React.FC = () => {
 
         setEvent(processedEvent);
         setLoading(false);
+        // Cached events don't have registration_required, keep as null (button won't show)
+        setRegistrationRequired(null);
 
         const totalDuration = Date.now() - startTime
         if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEventDetails: Completed (cached) - ${totalDuration}ms total`)
@@ -525,6 +529,8 @@ const EventDetails: React.FC = () => {
         if (practiceFromStore) {
           setEvent(practiceFromStore)
           setLoading(false)
+          // Practices don't require registration button (filtered by title check anyway)
+          setRegistrationRequired(false)
           const totalDuration = Date.now() - startTime
           if (__DEV__) console.log(`⏱️ [Event ${id}] fetchEventDetails: Completed (practice from store) - ${totalDuration}ms total`)
           return
@@ -629,6 +635,9 @@ const EventDetails: React.FC = () => {
       })
 
       setRegistered(isUserEnrolled)
+
+      // Save registration_required from API response
+      setRegistrationRequired(eventData.registration_required ?? null)
 
       // Fetch enrollment options to determine if registration is available (for non-practice events)
       if (!processedEvent.title.toLowerCase().includes('practice')) {
@@ -841,6 +850,8 @@ const EventDetails: React.FC = () => {
     }
 
     setEvent(mockEvent)
+    // Mock/fallback events should not show registration button
+    setRegistrationRequired(false)
   }
 
   const getStatusColor = (status: string) => {
@@ -1136,10 +1147,12 @@ const EventDetails: React.FC = () => {
 
           {/* Only show register button if:
               1. Not a practice
-              2. Enrollment options loaded
-              3. Registration is available (can_enroll_free OR credit_cost > 0 OR stripe_price_id OR membership_plan_id)
+              2. registration_required is true (from API)
+              3. Enrollment options loaded
+              4. Registration is available (can_enroll_free OR credit_cost > 0 OR stripe_price_id OR membership_plan_id)
           */}
           {!event.title.toLowerCase().includes('practice') &&
+           registrationRequired === true &&
            enrollmentOptionsLoaded &&
            enrollmentOptions &&
            (enrollmentOptions.can_enroll_free || enrollmentOptions.credit_cost > 0 || enrollmentOptions.stripe_price_id || enrollmentOptions.membership_plan_id) && (


### PR DESCRIPTION
## :clipboard: Title
Add registration_required field support to control event registration button visibility

## :sparkles: Changes Made
- Add `registration_required` field to `ApiEventResponse` interface
- Add `registrationRequired` state variable to track API response value
- Only show "Register for Event" button when `registration_required === true`
- Hide button when `registration_required === false` or `null`
- Explicitly set `registrationRequired` in all code paths for robustness:
  - Cached events: `null` (button hidden)
  - Practice from store: `false` (button hidden)
  - API success: use API value
  - Fallback/mock data: `false` (button hidden)

## :brain: Reason for Changes
Backend added `registration_required` field to `GET /events/{id}` endpoint. Frontend needs to respect this field to control whether users can register for specific events.

## :test_tube: Testing Performed
- [x] API endpoint tested - confirmed `registration_required` field returns `true` or `false`
- [x] Code paths analyzed for robustness
- [x] ESLint passed (no new warnings)

## :link: Related Trello Task
N/A

## Notes for Reviewer
- When `registration_required=true`: Button shows (if other conditions met)
- When `registration_required=false`: Button hidden
- When `registration_required=null/undefined`: Button hidden (safe default)
- No changes to authentication or API client code

🤖 Generated with [Claude Code](https://claude.com/claude-code)