### PR TITLE
fix: Refresh biometric state on screen focus to fix account switching…

### DIFF
--- a/app/screens/profile-options/notificationSettings.tsx
+++ b/app/screens/profile-options/notificationSettings.tsx
@@ -24,6 +24,7 @@ import {
   isBiometricLoginEnabled,
   disableBiometricLogin,
   getBiometricDisplayName,
+  getBiometricCredentials,
   type BiometricCapability,
 } from "@/utils/biometricAuth";
 import { useAppSelector } from "@/store/hooks";
@@ -59,6 +60,7 @@ const NotificationSettingsScreen: React.FC = () => {
     supportedTypes: [],
   });
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
+  const [biometricLinkedEmail, setBiometricLinkedEmail] = useState<string | null>(null);
 
   // Get user data from Redux store
   const user = useAppSelector((state) => state.user.data);
@@ -91,6 +93,14 @@ const NotificationSettingsScreen: React.FC = () => {
       if (capability.isAvailable) {
         const isEnabled = await isBiometricLoginEnabled();
         setSettings(prev => ({ ...prev, biometricLogin: isEnabled }));
+
+        // Get the linked email to display
+        if (isEnabled) {
+          const credentials = await getBiometricCredentials();
+          setBiometricLinkedEmail(credentials?.email || null);
+        } else {
+          setBiometricLinkedEmail(null);
+        }
       }
     } catch (error) {
       // Error checking biometric availability
@@ -196,6 +206,7 @@ const NotificationSettingsScreen: React.FC = () => {
         const success = await disableBiometricLogin();
         if (success) {
           setSettings(prev => ({ ...prev, biometricLogin: false }));
+          setBiometricLinkedEmail(null);
           Alert.alert(
             "Biometric Login Disabled",
             `${getBiometricDisplayName(biometricCapability.biometricType)} login has been disabled.`
@@ -463,7 +474,9 @@ const NotificationSettingsScreen: React.FC = () => {
           {biometricCapability.isAvailable && (
             renderSettingRow(
               `${getBiometricDisplayName(biometricCapability.biometricType)} Login`,
-              `Use ${getBiometricDisplayName(biometricCapability.biometricType)} to sign in quickly and securely`,
+              biometricLinkedEmail
+                ? `Linked to ${biometricLinkedEmail}`
+                : `Use ${getBiometricDisplayName(biometricCapability.biometricType)} to sign in quickly and securely`,
               "biometricLogin",
               biometricCapability.biometricType === 'face' ? 'scan' : 'finger-print',
               false

--- a/components/auth/BiometricLogin.tsx
+++ b/components/auth/BiometricLogin.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Alert, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
+import { useFocusEffect } from 'expo-router';
 import {
   checkBiometricCapability,
   performBiometricLogin,
   getBiometricDisplayName,
   saveBiometricCredentials,
   isBiometricLoginEnabled,
+  getBiometricCredentials,
   type BiometricCapability,
   type BiometricCredentials,
 } from '@/utils/biometricAuth';
@@ -32,24 +34,46 @@ const BiometricLogin: React.FC<BiometricLoginProps> = ({
   });
   const [isBiometricEnabled, setIsBiometricEnabled] = useState(false);
   const [isCheckingBiometric, setIsCheckingBiometric] = useState(false);
+  const [storedEmail, setStoredEmail] = useState<string | null>(null);
 
+  // Check biometric capability once on mount
   useEffect(() => {
-    initializeBiometric();
+    const checkCapability = async () => {
+      try {
+        const capability = await checkBiometricCapability();
+        setBiometricCapability(capability);
+      } catch (error) {
+        console.error('Error checking biometric capability:', error);
+      }
+    };
+    checkCapability();
   }, []);
 
-  const initializeBiometric = async () => {
-    try {
-      const capability = await checkBiometricCapability();
-      setBiometricCapability(capability);
+  // Re-check biometric enabled state every time the screen comes into focus
+  // This ensures we pick up changes made in settings or after switching accounts
+  useFocusEffect(
+    useCallback(() => {
+      const refreshBiometricState = async () => {
+        try {
+          if (biometricCapability.isAvailable) {
+            const enabled = await isBiometricLoginEnabled();
+            setIsBiometricEnabled(enabled);
 
-      if (capability.isAvailable) {
-        const enabled = await isBiometricLoginEnabled();
-        setIsBiometricEnabled(enabled);
-      }
-    } catch (error) {
-      console.error('Error initializing biometric:', error);
-    }
-  };
+            // Get the stored email to display which account is linked
+            if (enabled) {
+              const credentials = await getBiometricCredentials();
+              setStoredEmail(credentials?.email || null);
+            } else {
+              setStoredEmail(null);
+            }
+          }
+        } catch (error) {
+          console.error('Error refreshing biometric state:', error);
+        }
+      };
+      refreshBiometricState();
+    }, [biometricCapability.isAvailable])
+  );
 
   const handleBiometricLogin = async () => {
     if (isLoading || isCheckingBiometric) return;
@@ -169,6 +193,12 @@ const BiometricLogin: React.FC<BiometricLoginProps> = ({
           Or sign in with {getBiometricDisplayName(biometricCapability.biometricType)}
         </Text>
 
+        {storedEmail && (
+          <Text style={styles.storedEmailText}>
+            as {storedEmail}
+          </Text>
+        )}
+
         <TouchableOpacity
           style={[
             styles.biometricButton,
@@ -203,8 +233,15 @@ const styles = StyleSheet.create({
   loginWithText: {
     color: '#AAAAAA',
     fontSize: 14,
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  storedEmailText: {
+    color: '#FFD700',
+    fontSize: 13,
     marginBottom: 15,
     textAlign: 'center',
+    fontWeight: '500',
   },
   biometricButton: {
     width: 70,


### PR DESCRIPTION
… issue

When switching between accounts and enabling/disabling biometrics, the login screen was showing stale biometric state because it only checked once on mount. Now uses useFocusEffect to refresh the biometric enabled state and stored credentials every time the login screen comes into focus.

Also displays the linked account email in both the login screen and settings screen so users can see which account biometrics will log into.

