### PR TITLE
fix: Empty state icon colors and calendar day selection highlight

### DIFF
--- a/app/(athlete)/screens/events.tsx
+++ b/app/(athlete)/screens/events.tsx
@@ -304,7 +304,7 @@ const EventsScreen: React.FC = () => {
 
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
-      <Ionicons name="calendar-outline" size={50} color="#333" />
+      <Ionicons name="calendar-outline" size={50} color="#FCA311" />
       <Text style={styles.emptyText}>No events found</Text>
       <Text style={styles.emptySubtext}>
         {activeFilter !== "All"

--- a/components/calendar/CalendarCard.tsx
+++ b/components/calendar/CalendarCard.tsx
@@ -11,50 +11,48 @@ interface CalendarCardProps {
 
 const CalendarCard: React.FC<CalendarCardProps> = ({ selectedDate, events, onDayPress, minDate }) => {
   // Create marked dates object
-  const markedDates = {
-    // Selected date
-    [selectedDate]: {
-      selected: true,
-      selectedColor: "#FCA311",
-      selectedTextColor: "#000000",
+  const markedDates = Object.entries(events).reduce(
+    (acc, [date, dateEvents]) => {
+      const dots = []
+
+      // Check for matches (orange dots)
+      if (dateEvents.some((event) => event.type === "match")) {
+        dots.push({ key: "match", color: "#FCA311" })
+      }
+
+      // Check for other event types (green dots)
+      // This includes course, practice, or any other type that's not match
+      if (dateEvents.some((event) => event.type !== "match")) {
+        dots.push({ key: "event", color: "#4ade80" })
+      }
+
+      // For the selected date, include both selection styling AND dots
+      if (date === selectedDate) {
+        acc[date] = {
+          selected: true,
+          selectedColor: "#FCA311",
+          selectedTextColor: "#000000",
+          dots,
+          marked: dots.length > 0,
+        }
+      } else {
+        acc[date] = {
+          dots,
+          marked: dots.length > 0,
+        }
+      }
+
+      return acc
     },
-
-    // Dates with events
-    ...Object.entries(events).reduce(
-      (acc, [date, dateEvents]) => {
-        // If it's the selected date, we still want to show the dots
-        const dots = []
-
-        // Check for matches (orange dots)
-        if (dateEvents.some((event) => event.type === "match")) {
-          dots.push({ key: "match", color: "#FCA311" })
-        }
-
-        // Check for other event types (green dots)
-        // This includes course, practice, or any other type that's not match
-        if (dateEvents.some((event) => event.type !== "match")) {
-          dots.push({ key: "event", color: "#4ade80" })
-        }
-
-        // For the selected date, we want both the selection and the dots
-        if (date === selectedDate) {
-          acc[date] = {
-            ...acc[date],
-            dots,
-            marked: dots.length > 0,
-          }
-        } else {
-          acc[date] = {
-            dots,
-            marked: dots.length > 0,
-          }
-        }
-
-        return acc
+    // Initialize with selected date (in case it has no events)
+    {
+      [selectedDate]: {
+        selected: true,
+        selectedColor: "#FCA311",
+        selectedTextColor: "#000000",
       },
-      {} as Record<string, any>,
-    ),
-  }
+    } as Record<string, any>,
+  )
 
   return (
     <View className="rounded-xl bg-[#121212] overflow-hidden">

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -22,5 +22,7 @@ export const COLORS = {
   // Chart colors (using primary gold)
   chart: "#FCA311",
   chartBackground: "rgba(252, 163, 17, 0.1)",
+  // Empty state icon color
+  emptyState: "#FCA311",
 }
 


### PR DESCRIPTION
- Fix events screen empty state icon color from dark gray to gold (#FCA311)
- Add emptyState color constant to COLORS for EmptyState component
- Fix calendar to properly highlight selected days that have events (previously the selection styling was being overwritten by event dots)

