### PR TITLE
fix: Standardize empty state icon colors to gold (#FCA311)

### DIFF
--- a/app/(coach)/screens/matchHistory.tsx
+++ b/app/(coach)/screens/matchHistory.tsx
@@ -614,7 +614,7 @@ const getStatusIndicator = (status: string) => {
     
     return (
       <View style={styles.emptyContainer}>
-        <FontAwesome6 name="history" size={50} color="#333" />
+        <FontAwesome6 name="clock-rotate-left" size={50} color="#FCA311" />
         <Text style={styles.emptyText}>No match history found</Text>
         <Text style={styles.emptySubtext}>
           {filteredMatches.length === 0 && matches.length > 0 

--- a/app/screens/profile-options/waivers.tsx
+++ b/app/screens/profile-options/waivers.tsx
@@ -179,7 +179,7 @@ const WaiversScreen: React.FC = () => {
 
   const renderEmptyState = () => (
     <View style={styles.emptyState}>
-      <Ionicons name="document-text-outline" size={64} color={COLORS.textSecondary} />
+      <Ionicons name="document-text-outline" size={64} color={COLORS.primary} />
       <Text style={styles.emptyTitle}>No Waivers</Text>
       <Text style={styles.emptyDescription}>
         You haven't uploaded any waivers yet. Tap the button below to upload your first waiver document.

--- a/components/feedback/EmptyBookingState.tsx
+++ b/components/feedback/EmptyBookingState.tsx
@@ -67,7 +67,7 @@ const EmptyBookingsState: React.FC<EmptyBookingsStateProps> = ({
         alignItems: 'center' 
       }}
     >
-      <FontAwesome5 name={content.icon} size={32} color={colors.textSecondary} />
+      <FontAwesome5 name={content.icon} size={32} color={colors.primary} />
       <Text 
         style={{ 
           color: colors.text, 


### PR DESCRIPTION
- Fix matchHistory.tsx: Change icon from 'history' to 'clock-rotate-left' and color from #333 (invisible on dark bg) to #FCA311 (gold)
- Fix waivers.tsx: Change icon color from COLORS.textSecondary to COLORS.primary
- Fix EmptyBookingState.tsx: Change icon color from textSecondary to primary

All empty state icons now consistently use the gold primary color for visibility.

