### PR TITLE
fix: Prevent keyboard from covering upload waiver modal

### DIFF
--- a/app/screens/profile-options/waivers.tsx
+++ b/app/screens/profile-options/waivers.tsx
@@ -11,6 +11,8 @@ import {
   TextInput,
   Modal,
   StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
@@ -303,7 +305,10 @@ const WaiversScreen: React.FC = () => {
           setNotes("");
         }}
       >
-        <View style={styles.modalOverlay}>
+        <KeyboardAvoidingView
+          style={styles.modalOverlay}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
           <View style={styles.modalContent}>
             <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>Upload Waiver</Text>
@@ -366,7 +371,7 @@ const WaiversScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     </SafeAreaView>
   );


### PR DESCRIPTION
Wrap modal content with KeyboardAvoidingView so the notes input remains visible when the keyboard is open.

