### PR TITLE
fix: Hide empty membership groups and allow multiple memberships

### DIFF
--- a/app/(athlete)/screens/membership/index.tsx
+++ b/app/(athlete)/screens/membership/index.tsx
@@ -415,48 +415,56 @@ const MembershipScreen: React.FC = () => {
       {/* Content based on active tab */}
       <View className="flex-1">
         {activeTab === 'memberships' ? (
-          userMemberships.length > 0 && !isExpiredMembership ? (
-            <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+          <MembershipPurchaseList
+            onPurchaseSuccess={refreshMembershipData}
+            onOpenPaymentWebView={handleOpenPaymentWebView}
+            onPurchaseCompleted={() => loadMembershipDataWithRetry()}
+            hasExistingMembership={false}
+            headerComponent={
               <View className="px-4 py-3">
-                <View className="mb-6">
-                  <View className="pb-2 mb-3 border-b border-[#222222]">
-                    <Text className="text-white-100 text-base font-semibold">Your Current Membership</Text>
+                {/* Show all current memberships if user has any */}
+                {userMemberships.length > 0 && !isExpiredMembership && (
+                  <View className="mb-6">
+                    <View className="pb-2 mb-3 border-b border-[#222222]">
+                      <Text className="text-white-100 text-base font-semibold">
+                        {userMemberships.length > 1 ? "Your Current Memberships" : "Your Current Membership"}
+                      </Text>
+                    </View>
+                    {userMemberships.map((membership, index) => (
+                      <View key={membership.id || index} style={{ marginBottom: index < userMemberships.length - 1 ? 12 : 0 }}>
+                        <MembershipDetails
+                          membership={membership}
+                          onRefresh={refreshMembershipData}
+                        />
+                      </View>
+                    ))}
                   </View>
-                  <MembershipDetails
-                    membership={userMemberships[0]}
-                    onRefresh={refreshMembershipData}
-                  />
+                )}
+
+                {/* Show expired membership notice */}
+                {isExpiredMembership && (
+                  <View className="mb-4 rounded-lg border border-[#b91c1c] bg-[#2f1a1a] p-3">
+                    <Text className="text-red-300 text-sm font-semibold">Your previous membership has expired.</Text>
+                    <Text className="text-[#e5e7eb] text-xs mt-1">
+                      Select a new plan below to continue your access.
+                    </Text>
+                  </View>
+                )}
+
+                {/* Available plans section header */}
+                <View className="mb-3">
+                  <View className="pb-2 mb-3 border-b border-[#222222]">
+                    <Text className="text-white-100 text-base font-semibold">Available Membership Plans</Text>
+                    <Text className="text-[#999999] text-xs mt-1">
+                      {userMemberships.length > 0 && !isExpiredMembership
+                        ? "Add another membership to your account"
+                        : "Choose a plan to get started with RISE"}
+                    </Text>
+                  </View>
                 </View>
               </View>
-            </ScrollView>
-          ) : (
-            <MembershipPurchaseList
-              onPurchaseSuccess={refreshMembershipData}
-              onOpenPaymentWebView={handleOpenPaymentWebView}
-              onPurchaseCompleted={() => loadMembershipDataWithRetry()}
-              hasExistingMembership={false}
-              headerComponent={
-                <View className="px-4 py-3">
-                  {isExpiredMembership && (
-                    <View className="mb-4 rounded-lg border border-[#b91c1c] bg-[#2f1a1a] p-3">
-                      <Text className="text-red-300 text-sm font-semibold">Your previous membership has expired.</Text>
-                      <Text className="text-[#e5e7eb] text-xs mt-1">
-                        Select a new plan below to continue your access.
-                      </Text>
-                    </View>
-                  )}
-                  <View className="mb-3">
-                    <View className="pb-2 mb-3 border-b border-[#222222]">
-                      <Text className="text-white-100 text-base font-semibold">Available Membership Plans</Text>
-                      <Text className="text-[#999999] text-xs mt-1">
-                        Choose a plan to get started with RISE
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              }
-            />
-          )
+            }
+          />
         ) : activeTab === 'credits' ? (
           // Credits tab content - using actual credits component
           <View className="flex-1">

--- a/components/membership/MembershipPurchaseList.tsx
+++ b/components/membership/MembershipPurchaseList.tsx
@@ -125,17 +125,41 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
           return;
         }
 
-        const initialSections: MembershipSection[] = membershipTypes.map((type) => ({
-          id: type.id,
-          title: type.name,
-          description: type.description || "",
-          data: [],
-          loading: false,
-          error: null,
-          loaded: false,
-        }));
+        // Pre-fetch plans for all membership types to determine which have visible plans
+        const sectionsWithPlans = await Promise.all(
+          membershipTypes.map(async (type) => {
+            const plansResult = await fetchPlansWithRetry(type.id);
+            const plans = plansResult.error ? [] : (plansResult.data || []);
+            const hasVisiblePlans = plans.length > 0;
 
-        setMembershipSections(initialSections);
+            return {
+              id: type.id,
+              title: type.name,
+              description: type.description || "",
+              data: hasVisiblePlans ? plans : [{
+                id: `${type.id}_placeholder`,
+                name: "",
+                description: "",
+                benefits: "",
+                price: 0,
+              }],
+              loading: false,
+              error: plansResult.error ? {
+                message: plansResult.error.message,
+                type: plansResult.error.type || "unknown",
+              } : null,
+              loaded: true,
+              hasVisiblePlans,
+            };
+          })
+        );
+
+        // Only include sections that have visible plans
+        const visibleSections = sectionsWithPlans.filter(
+          (section) => section.hasVisiblePlans
+        );
+
+        setMembershipSections(visibleSections);
       } catch (error) {
         console.warn("⚠️ Unexpected error fetching membership data:", error);
         setError("Failed to load membership information");
@@ -267,26 +291,13 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
   };
 
   const handleToggleSection = (sectionId: string) => {
-    console.log("🟡 Section toggle - ID:", sectionId, "| Current expanded:", expandedSectionId);
     if (expandedSectionId === sectionId) {
-      console.log("🟡 Collapsing section");
       setExpandedSectionId(null);
       return;
     }
 
-    console.log("🟡 Expanding section");
     setExpandedSectionId(sectionId);
-    const target = membershipSections.find((section) => section.id === sectionId);
-    if (target && !target.loaded && !target.loading) {
-      console.log("🟡 Loading section plans for:", sectionId);
-      loadSectionPlans(sectionId);
-    } else {
-      console.log("🟡 Section already loaded or loading:", {
-        loaded: target?.loaded,
-        loading: target?.loading,
-        plansCount: target?.data?.length
-      });
-    }
+    // Plans are pre-loaded, so no need to load on expand
   };
 
   const retryFetchPlans = async (sectionId: string) => {
@@ -313,7 +324,6 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
   };
 
   const handlePurchase = async (planId: string, planName: string) => {
-    console.log("🔷 handlePurchase called - Plan:", planName, "| ID:", planId);
     setPurchaseLoadingId(planId);
 
     // Set a timeout to reset loading state if request takes too long
@@ -330,16 +340,13 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
     }, 30000); // 30 second timeout
 
     try {
-      console.log("🔷 Calling purchaseMembershipPlan API...");
       // Call API which now returns { data, error }
       const result: any = await purchaseMembershipPlan(planId);
-      console.log("🔷 API call completed. Result:", result);
 
       // Clear timeout if request completes
       clearTimeout(timeoutId);
 
       if (result?.error) {
-        console.log("🔷 Error detected - Status:", result.error.status, "| Message:", result.error.message);
         const status: number | undefined = result.error.status;
         let backendMessage: string | undefined = result.error.message;
 
@@ -363,7 +370,6 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
         }
 
         if (status === 409) {
-          console.log("🔷 Showing 'Already Subscribed' dialog");
           dialog.show(
             "Already Subscribed",
             backendMessage || "You already have an active membership for this plan.",
@@ -374,7 +380,6 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
           return;
         }
 
-        console.log("🔷 Showing 'Purchase Failed' dialog with message:", backendMessage);
         dialog.show(
           "Purchase Failed",
           backendMessage || "Unable to initiate purchase. Please try again later or contact support.",
@@ -389,10 +394,6 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
       const data = result?.data;
       if (data && data.payment_url && onOpenPaymentWebView) {
         onOpenPaymentWebView(data.payment_url);
-        // Defer refresh until the WebView flow reports completion
-        if (onPurchaseCompleted) {
-          console.log("ℹ️ Purchase initiated via WebView; deferring onPurchaseCompleted until flow finishes.");
-        }
         return;
       } else {
         dialog.show(
@@ -588,19 +589,6 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
     </View>
   );
 
-  // If user has existing membership, show header but minimal upgrade content
-  if (hasExistingMembership) {
-    return (
-      <View style={styles.container}>
-        {headerComponent}
-        <View style={{ padding: 16 }}>
-          <Text style={{ color: '#999999', fontSize: 14, textAlign: 'center', lineHeight: 20 }}>
-            Membership upgrades and changes will be available soon.{'\n'}Contact support for assistance with your current membership.
-          </Text>
-        </View>
-      </View>
-    );
-  }
 
   return (
     <>
@@ -614,44 +602,9 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
             return null;
           }
 
-          // Handle loading state
-          if (section.loading) {
-            return (
-              <View style={styles.sectionStateContainer}>
-                <ActivityIndicator size="small" color="#FCA311" />
-                <Text style={styles.sectionStateText}>Loading plans...</Text>
-              </View>
-            );
-          }
-
-          // Handle error state
-          if (section.error) {
-            return (
-              <View style={styles.sectionStateContainer}>
-                <Text style={styles.sectionErrorText}>
-                  {section.error.type === 'auth'
-                    ? 'Authentication failed. Please log in again.'
-                    : section.error.message}
-                </Text>
-                <TouchableOpacity
-                  style={styles.retryButton}
-                  onPress={() => retryFetchPlans(section.id)}
-                >
-                  <Text style={styles.retryButtonText}>Retry</Text>
-                </TouchableOpacity>
-              </View>
-            );
-          }
-
-          // Handle empty state (no plans available)
+          // Skip placeholder items (sections with no visible plans are already filtered out)
           if (item.id.endsWith('_placeholder')) {
-            return (
-              <View style={styles.sectionStateContainer}>
-                <Text style={styles.sectionStateText}>
-                  No plans available for this membership type
-                </Text>
-              </View>
-            );
+            return null;
           }
 
           // Render normal plan card


### PR DESCRIPTION
- Pre-fetch plans for all membership types on initial load
- Filter out membership groups that have no visible plans
- Allow users with existing memberships to purchase additional memberships
- Display all user memberships (not just the first one)
- Dynamic header text: "Your Current Membership" vs "Your Current Memberships"
- Show current memberships at top with available plans below
- Update subtitle text based on whether user has existing membership
- Remove "upgrades coming soon" message that blocked additional purchases
- Clean up debug console.log statements

