### PR TITLE
[Bugfix] Fix membership billing frequency display showing incorrect interval

### DIFF
--- a/components/membership/MembershipPurchaseList.tsx
+++ b/components/membership/MembershipPurchaseList.tsx
@@ -25,6 +25,7 @@ interface MembershipPlan {
   benefits: string;
   price?: number | string;
   joining_fee_price?: string;
+  interval?: string;
 }
 
 interface MembershipType {
@@ -443,6 +444,29 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
     );
   };
 
+  // Format billing interval for display
+  // Backend values: "month", "week", "biweekly", "year", "day", "once"
+  const formatBillingInterval = (interval?: string): string => {
+    if (!interval) return "/month"; // Default fallback
+    const int = interval.toLowerCase().trim();
+    switch (int) {
+      case "month":
+        return "/month";
+      case "week":
+        return "/week";
+      case "biweekly":
+        return "/bi-weekly";
+      case "year":
+        return "/year";
+      case "day":
+        return "/day";
+      case "once":
+        return " (one-time)";
+      default:
+        return `/${int}`;
+    }
+  };
+
   const renderPlanCard = ({ item }: { item: MembershipPlan }) => {
     const joiningFeeRaw = item.joining_fee_price?.toString().trim() ?? "";
     const joiningFeeClean = joiningFeeRaw.replace(/[^0-9.]/g, "");
@@ -456,6 +480,9 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
     const formattedPrice = item.price
       ? (typeof item.price === 'number' ? `$${item.price.toFixed(2)}` : item.price.toString().replace(/\$\$/g, '$'))
       : null;
+
+    // Format billing interval for display
+    const formattedInterval = formatBillingInterval(item.interval);
 
     return (
       <View style={styles.accordionPlanCard}>
@@ -479,7 +506,7 @@ const MembershipPurchaseList: React.FC<MembershipPurchaseListProps> = ({
               {formattedPrice ? (
                 <>
                   <Text style={styles.priceAmount}>{formattedPrice}</Text>
-                  <Text style={styles.pricePeriod}>/bi-weekly</Text>
+                  <Text style={styles.pricePeriod}>{formattedInterval}</Text>
                 </>
               ) : (
                 <Text style={styles.priceUnavailable}>Contact for pricing</Text>


### PR DESCRIPTION
## :clipboard: Title
Fix membership billing frequency display - use API `interval` field instead of hardcoded value

---

## :sparkles: Changes Made
- Added `interval?: string` field to `MembershipPlan` interface to receive API data
- Created `formatBillingInterval()` helper function to convert API values to user-friendly display format
- Replaced hardcoded `/bi-weekly` text with dynamic `{formattedInterval}` from API response
- Handles all backend-supported intervals: `month`, `week`, `biweekly`, `year`, `day`, `once`

---

## :brain: Reason for Changes
Mostapha reported that "Performance Gym Membership" was displaying `$47.00 /bi-weekly` when it should show `$47.00 /month`.

**Root Cause**: The billing frequency was hardcoded as `/bi-weekly` in `MembershipPurchaseList.tsx:482`, ignoring the actual `interval` field returned by the API.

**Verification**: 
- Tested the `/memberships/{id}/plans` API endpoint
- Confirmed backend returns `interval: "month"` for Performance Gym Membership
- Confirmed all 19 visible plans have valid interval values (`month`, `week`, `year`)

---

## :test_tube: Testing Performed
- [x] Verified API response structure via Python test script
- [x] Confirmed backend returns correct `interval` values for all membership plans
- [x] ESLint passed (no new warnings)
- [x] TypeScript compilation successful
- [x] Verified no other components have same hardcoded issue

---

## Screenshots or Screen Recording (Optional)
N/A - Logic fix, no visual design changes

---

## :link: Related Trello Task
Reported by Mostapha via direct communication

---

## Notes for Reviewer (Optional)
- The fix handles all backend-supported intervals including future values
- Default fallback to `/month` if interval is null/undefined (edge case safety)
- Swagger documentation shows `payment_frequency` but actual API uses `interval` - this fix uses the correct field name based on actual API testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)