### PR TITLE
feat: Add My Events feature and improve Schedule page UX

### DIFF
--- a/app/(admin)/(tabs)/dashboard.tsx
+++ b/app/(admin)/(tabs)/dashboard.tsx
@@ -412,6 +412,13 @@ export default function AdminDashboard() {
       colors: ["#8E2DE2", "#4A00E0"] as [string, string],
     },
     {
+      label: "My Events",
+      route: "/(admin)/screens/my-events",
+      icon: "calendar-day",
+      description: "Events you're registered for",
+      colors: ["#2C3E50", "#3498DB"] as [string, string],
+    },
+    {
       label: "Staff",
       route: "/(admin)/(tabs)/staff",
       icon: "user-tie",

--- a/app/(admin)/(tabs)/schedule.tsx
+++ b/app/(admin)/(tabs)/schedule.tsx
@@ -774,7 +774,7 @@ export default function ScheduleScreen() {
       ) : (
         /* Calendar View */
         <View style={{ flex: 1 }}>
-          <SharedCalendar userRole="athlete" title="" embedded={true} />
+          <SharedCalendar userRole="admin" title="" embedded={true} />
         </View>
       )}
     </SafeAreaView>

--- a/app/(admin)/screens/_layout.tsx
+++ b/app/(admin)/screens/_layout.tsx
@@ -9,6 +9,7 @@ export default function AdminScreensLayout() {
       <Stack.Screen name="website-content" options={{ headerShown: false }} />
       <Stack.Screen name="profile" options={{ headerShown: false }} />
       <Stack.Screen name="change-password" options={{ headerShown: false }} />
+      <Stack.Screen name="my-events" options={{ headerShown: false }} />
     </Stack>
   );
 }

--- a/app/(admin)/screens/my-events.tsx
+++ b/app/(admin)/screens/my-events.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   View, Text, FlatList, TouchableOpacity, Image,
   StyleSheet, RefreshControl, ActivityIndicator
@@ -7,41 +7,42 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { useDispatch, useSelector } from "react-redux";
-import { fetchEvents } from "@/store/slices/eventsSlice";
+import { useSelector } from "react-redux";
 import type { RootState } from "@/store";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import dayjs from "dayjs";
 import images from "@/constants/images";
 import { resolveImageSource } from "@/utils/imageSource";
-import Constants from "expo-constants";
+import axios from "axios";
+import { API_URL } from "@/utils/api";
 
-export interface Event {
+interface MyEvent {
   id: string;
   title: string;
   date: string;
   time: string;
   location: string;
   image: string;
-  type: "game" | "match" | "practice" | "course" | "other";
-  program?: { 
+  description: string;
+  program?: {
     id: string;
+    name?: string;
+    type?: string;
     photo_url?: string;
+    description?: string;
   };
 }
 
-
-const EventsScreen: React.FC = () => {
-  const [events, setEvents] = useState<Event[]>([]);
-  const [filteredEvents, setFilteredEvents] = useState<Event[]>([]);
+const MyEventsScreen: React.FC = () => {
+  const [events, setEvents] = useState<MyEvent[]>([]);
+  const [filteredEvents, setFilteredEvents] = useState<MyEvent[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [refreshing, setRefreshing] = useState<boolean>(false);
   const [activeFilter, setActiveFilter] = useState<string>("All");
   const [selectedMonth, setSelectedMonth] = useState<dayjs.Dayjs>(dayjs());
   const router = useRouter();
-  const dispatch = useDispatch();
   const user = useSelector((state: RootState) => state.user.data);
-  const reduxEvents = useSelector((state: RootState) => state.events);
+  const hasFetchedRef = useRef(false);
 
   const getToken = useCallback(async () => {
     let token = user?.token;
@@ -52,74 +53,84 @@ const EventsScreen: React.FC = () => {
     return token;
   }, [user?.token]);
 
-  const fetchData = useCallback(async () => {
-    const token = await getToken();
-    if (!token) return;
-    dispatch(fetchEvents(token) as any);
-  }, [dispatch, getToken]);
+  const fetchMyEvents = useCallback(async () => {
+    try {
+      const token = await getToken();
+      if (!token) return;
 
-  useEffect(() => {
-    setLoading(true);
-    fetchData().finally(() => {
-      setLoading(false);
-      setRefreshing(false);
-    });
-  }, [fetchData]);
-
-  useEffect(() => {
-    const allEvents: Event[] = [];
-    const seenEventIds = new Set<string>();
-
-    // Convert Redux events
-    // All items from the events API are "events" - they should navigate to event-details
-    Object.values(reduxEvents.byDate).forEach((eventGroup: any[]) => {
-      eventGroup.forEach((event) => {
-        // ✅ Validate event ID exists and is unique
-        if (event.id && !seenEventIds.has(event.id)) {
-          // ✅ Validate date before adding to prevent "Invalid Date"
-          const eventDate = dayjs(event.date);
-          if (eventDate.isValid()) {
-            seenEventIds.add(event.id);
-            allEvents.push({
-              id: event.id,
-              title: event.title || "Untitled Event",
-              date: eventDate.format("YYYY-MM-DD"),
-              time: event.time || "TBD",
-              location: event.location || "TBD",
-              image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
-              // Always use "other" for events from the events API - they should go to event-details
-              // The visual "type" from the slice is just for display, not navigation
-              type: "other",
-              program: event.program?.id ? {
-                id: event.program.id,
-                photo_url: event.program.photo_url
-              } : undefined,
-            });
-          } else {
-            console.warn(`⚠️ Invalid date for event ${event.id}: ${event.date}`);
-          }
-        } else if (!event.id) {
-          console.warn(`⚠️ Event missing ID, skipping:`, event);
-        }
+      const response = await axios.get(`${API_URL}/secure/schedule`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
+
+      const { events: rawEvents } = response.data;
+      const processedEvents: MyEvent[] = [];
+
+      if (rawEvents && Array.isArray(rawEvents)) {
+        rawEvents.forEach((event: any) => {
+          let eventDate = event.date;
+          if (!eventDate && event.start_at) {
+            if (event.start_at.includes('T')) {
+              eventDate = event.start_at.split('T')[0];
+            } else {
+              eventDate = event.start_at.split(' ')[0];
+            }
+          }
+
+          const parsedDate = dayjs(eventDate);
+          if (!parsedDate.isValid()) {
+            return;
+          }
+
+          let formattedTime = "TBD";
+          if (event.start_at) {
+            try {
+              const date = new Date(event.start_at);
+              if (!isNaN(date.getTime())) {
+                formattedTime = date.toLocaleTimeString('en-US', {
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true
+                });
+              }
+            } catch (e) {
+              formattedTime = "TBD";
+            }
+          }
+
+          processedEvents.push({
+            id: event.id,
+            title: event.program?.name || event.name || event.title || "Event",
+            date: parsedDate.format("YYYY-MM-DD"),
+            time: formattedTime,
+            location: (typeof event.location === 'object'
+              ? event.location?.name || event.location?.address
+              : event.location) || "TBD",
+            image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+            description: event.program?.description || event.description || "",
+            program: event.program,
+          });
+        });
+      }
+
+      const sortedEvents = processedEvents.sort((a, b) => {
+        return new Date(a.date).getTime() - new Date(b.date).getTime();
+      });
+
+      setEvents(sortedEvents);
+    } catch (error: any) {
+      console.error("Error fetching my events:", error);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+
+    setLoading(true);
+    fetchMyEvents().finally(() => {
+      setLoading(false);
     });
-
-
-    // Note: Matches are NOT included here - they are viewed from the Matches tab
-    // This Events screen only shows events from the events API
-
-    // Sort events chronologically (earliest date first)
-    const sortedEvents = allEvents.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    // Limit to 100 most recent/upcoming events for performance
-    const limitedEvents = sortedEvents.slice(0, 100);
-
-    setEvents(limitedEvents);
-  }, [reduxEvents.byDate]);
+  }, []);
 
   useEffect(() => {
     filterEvents(activeFilter, selectedMonth);
@@ -127,49 +138,7 @@ const EventsScreen: React.FC = () => {
 
   const onRefresh = () => {
     setRefreshing(true);
-    fetchData().finally(() => setRefreshing(false));
-  };
-
-  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
-    let filtered = events;
-
-    // First filter by month
-    const monthStart = month.startOf("month");
-    const monthEnd = month.endOf("month");
-    filtered = events.filter(event => {
-      const eventDate = dayjs(event.date);
-      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
-    });
-
-    // Then apply status filter
-    if (filter === "All") {
-      // "All" shows only today and future events (no past events) for the selected month
-      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
-    } else {
-      // Map UI filter labels to status values
-      const statusMapping: Record<string, string> = {
-        "Upcoming": "Upcoming",
-        "Today": "Today",
-        "Past": "Past"
-      };
-      const backendStatus = statusMapping[filter] || filter;
-      filtered = filtered.filter(event => getEventStatus(event.date) === backendStatus);
-    }
-
-    // Sort chronologically (earliest date first for upcoming, most recent first for past)
-    const sortedFiltered = filtered.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-
-      if (filter === "Past") {
-        // For past events, show most recent first
-        return dateB.getTime() - dateA.getTime();
-      }
-      // For upcoming/all, show earliest first
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    setFilteredEvents(sortedFiltered);
+    fetchMyEvents().finally(() => setRefreshing(false));
   };
 
   const getEventStatus = (date: string) => {
@@ -181,6 +150,34 @@ const EventsScreen: React.FC = () => {
     return "Upcoming";
   };
 
+  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
+    let filtered = events;
+
+    const monthStart = month.startOf("month");
+    const monthEnd = month.endOf("month");
+    filtered = events.filter(event => {
+      const eventDate = dayjs(event.date);
+      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
+    });
+
+    if (filter === "All") {
+      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
+    } else {
+      filtered = filtered.filter(event => getEventStatus(event.date) === filter);
+    }
+
+    const sortedFiltered = filtered.sort((a, b) => {
+      const dateA = new Date(a.date);
+      const dateB = new Date(b.date);
+      if (filter === "Past") {
+        return dateB.getTime() - dateA.getTime();
+      }
+      return dateA.getTime() - dateB.getTime();
+    });
+
+    setFilteredEvents(sortedFiltered);
+  };
+
   const getStatusColor = (status: string) => {
     switch (status) {
       case "Upcoming": return "#FCA311";
@@ -190,7 +187,7 @@ const EventsScreen: React.FC = () => {
     }
   };
 
-  const renderEventItem = ({ item }: { item: Event }) => {
+  const renderEventItem = ({ item }: { item: MyEvent }) => {
     const status = getEventStatus(item.date);
     const statusColor = getStatusColor(status);
 
@@ -199,17 +196,11 @@ const EventsScreen: React.FC = () => {
         style={styles.eventCard}
         activeOpacity={0.9}
         onPress={() => {
-          // All events from this screen go to event-details
-          // (Matches are viewed from the Matches tab, not here)
           router.push({
             pathname: "/screens/event-details/[id]",
-            params: {
-              id: item.id,
-              source: "homepage",
-            },
+            params: { id: item.id, source: "my-events" },
           });
         }}
-
       >
         <Image
           source={resolveImageSource(item.image || item.program?.photo_url, images.event)}
@@ -226,7 +217,7 @@ const EventsScreen: React.FC = () => {
           <View style={styles.eventInfo}>
             <View style={styles.infoRow}>
               <Ionicons name="calendar-outline" size={16} color="#FCA311" style={styles.infoIcon} />
-              <Text style={styles.infoText}>{item.date}</Text>
+              <Text style={styles.infoText}>{dayjs(item.date).format("MMM D, YYYY")}</Text>
             </View>
             <View style={styles.infoRow}>
               <Ionicons name="time-outline" size={16} color="#FCA311" style={styles.infoIcon} />
@@ -243,7 +234,7 @@ const EventsScreen: React.FC = () => {
   };
 
   const renderMonthSelector = () => {
-    const canGoBack = selectedMonth.isAfter(dayjs().subtract(1, "month"), "month");
+    const canGoBack = selectedMonth.isAfter(dayjs().subtract(3, "month"), "month");
     const canGoForward = selectedMonth.isBefore(dayjs().add(6, "months"), "month");
 
     return (
@@ -290,17 +281,12 @@ const EventsScreen: React.FC = () => {
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
       <Ionicons name="calendar-outline" size={50} color="#FCA311" />
-      <Text style={styles.emptyText}>No events found</Text>
+      <Text style={styles.emptyText}>No registered events</Text>
       <Text style={styles.emptySubtext}>
         {activeFilter !== "All"
-          ? `There are no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
-          : `No upcoming events in ${selectedMonth.format("MMMM YYYY")}`}
+          ? `You have no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
+          : `You haven't registered for any events yet`}
       </Text>
-      {activeFilter !== "All" && (
-        <TouchableOpacity style={styles.resetButton} onPress={() => setActiveFilter("All")}>
-          <Text style={styles.resetButtonText}>Show All Events</Text>
-        </TouchableOpacity>
-      )}
     </View>
   );
 
@@ -315,26 +301,25 @@ const EventsScreen: React.FC = () => {
             if (canGoBack) {
               router.back();
             } else {
-              router.replace("/(athlete)/(tabs)/home");
+              router.replace("/(admin)/(tabs)/dashboard");
             }
           }}
         >
           <Ionicons name="chevron-back" size={24} color="#F0F0F0" />
         </TouchableOpacity>
         <View style={styles.headerTextContainer}>
-          <Text style={styles.headerTitle}>Events</Text>
-          <Text style={styles.headerSubtitle}>Find & register for events</Text>
+          <Text style={styles.headerTitle}>My Events</Text>
+          <Text style={styles.headerSubtitle}>Events you're registered for</Text>
         </View>
         <View style={{ width: 40 }} />
       </View>
       {renderMonthSelector()}
       {renderFilterChips()}
 
-      {/* Info Section */}
       {!loading && events.length > 0 && (
         <View style={styles.infoContainer}>
-          <Text style={styles.infoText}>
-            Showing {filteredEvents.length} of {events.length} events • Sorted by date
+          <Text style={styles.countText}>
+            Showing {filteredEvents.length} of {events.length} registered events
           </Text>
         </View>
       )}
@@ -342,7 +327,7 @@ const EventsScreen: React.FC = () => {
       {loading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#FCA311" />
-          <Text style={styles.loadingText}>Loading events...</Text>
+          <Text style={styles.loadingText}>Loading your events...</Text>
         </View>
       ) : (
         <FlatList
@@ -366,12 +351,8 @@ const EventsScreen: React.FC = () => {
   );
 };
 
-
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#0C0B0B",
-  },
+  container: { flex: 1, backgroundColor: "#0C0B0B" },
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -389,20 +370,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  headerTextContainer: {
-    flex: 1,
-    alignItems: "center",
-  },
-  headerTitle: {
-    fontSize: 22,
-    fontWeight: "bold",
-    color: "#FFFFFF",
-  },
-  headerSubtitle: {
-    fontSize: 12,
-    color: "#999",
-    marginTop: 2,
-  },
+  headerTextContainer: { flex: 1, alignItems: "center" },
+  headerTitle: { fontSize: 22, fontWeight: "bold", color: "#FFFFFF" },
+  headerSubtitle: { fontSize: 12, color: "#999", marginTop: 2 },
   monthSelectorContainer: {
     flexDirection: "row",
     alignItems: "center",
@@ -412,12 +382,8 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: "#222",
   },
-  monthArrow: {
-    padding: 8,
-  },
-  monthArrowDisabled: {
-    opacity: 0.5,
-  },
+  monthArrow: { padding: 8 },
+  monthArrowDisabled: { opacity: 0.5 },
   monthText: {
     fontSize: 18,
     fontWeight: "600",
@@ -426,11 +392,7 @@ const styles = StyleSheet.create({
     minWidth: 150,
     textAlign: "center",
   },
-  filtersContainer: {
-    flexDirection: "row",
-    paddingHorizontal: 20,
-    paddingVertical: 15,
-  },
+  filtersContainer: { flexDirection: "row", paddingHorizontal: 20, paddingVertical: 15 },
   filterChip: {
     paddingHorizontal: 16,
     paddingVertical: 8,
@@ -438,126 +400,43 @@ const styles = StyleSheet.create({
     backgroundColor: "#1A1A1A",
     marginRight: 10,
   },
-  activeFilterChip: {
-    backgroundColor: "rgba(252, 163, 17, 0.2)",
-  },
-  filterChipText: {
-    color: "#999",
-    fontWeight: "500",
-    fontSize: 14,
-  },
-  activeFilterChipText: {
-    color: "#FCA311",
-    fontWeight: "600",
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  loadingText: {
-    color: "#999",
-    marginTop: 12,
-    fontSize: 16,
-  },
-  listContent: {
-    padding: 20,
-    paddingTop: 5,
-  },
+  activeFilterChip: { backgroundColor: "rgba(252, 163, 17, 0.2)" },
+  filterChipText: { color: "#999", fontWeight: "500", fontSize: 14 },
+  activeFilterChipText: { color: "#FCA311", fontWeight: "600" },
+  loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
+  loadingText: { color: "#999", marginTop: 12, fontSize: 16 },
+  listContent: { padding: 20, paddingTop: 5, paddingBottom: 100 },
   eventCard: {
     backgroundColor: "#1A1A1A",
     borderRadius: 16,
     overflow: "hidden",
     marginBottom: 20,
     shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 3.84,
     elevation: 5,
   },
-  eventImage: {
-    width: "100%",
-    height: 160,
-  },
-  eventDetails: {
-    padding: 16,
-  },
+  eventImage: { width: "100%", height: 160 },
+  eventDetails: { padding: 16 },
   eventHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "flex-start",
     marginBottom: 12,
   },
-  eventTitle: {
-    fontSize: 18,
-    fontWeight: "bold",
-    color: "#FFFFFF",
-    flex: 1,
-    marginRight: 8,
-  },
-  statusBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 12,
-  },
-  statusText: {
-    fontSize: 12,
-    fontWeight: "bold",
-  },
-  eventInfo: {
-    marginTop: 4,
-  },
-  infoRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  infoIcon: {
-    marginRight: 8,
-  },
-  infoContainer: {
-    paddingHorizontal: 20,
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: "#222",
-  },
-  infoText: {
-    color: "#999",
-    fontSize: 12,
-    textAlign: "center",
-  },
-  emptyContainer: {
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 40,
-    marginTop: 40,
-  },
-  emptyText: {
-    color: "#FFFFFF",
-    fontSize: 18,
-    fontWeight: "bold",
-    marginTop: 16,
-  },
-  emptySubtext: {
-    color: "#999",
-    fontSize: 14,
-    textAlign: "center",
-    marginTop: 8,
-    marginBottom: 24,
-  },
-  resetButton: {
-    backgroundColor: "rgba(252, 163, 17, 0.2)",
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-  },
-  resetButtonText: {
-    color: "#FCA311",
-    fontWeight: "bold",
-  },
+  eventTitle: { fontSize: 18, fontWeight: "bold", color: "#FFFFFF", flex: 1, marginRight: 8 },
+  statusBadge: { paddingHorizontal: 10, paddingVertical: 5, borderRadius: 12 },
+  statusText: { fontSize: 12, fontWeight: "bold" },
+  eventInfo: { marginTop: 4 },
+  infoRow: { flexDirection: "row", alignItems: "center", marginBottom: 8 },
+  infoIcon: { marginRight: 8 },
+  infoText: { color: "#999", fontSize: 14 },
+  infoContainer: { paddingHorizontal: 20, paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: "#222" },
+  countText: { color: "#999", fontSize: 12, textAlign: "center" },
+  emptyContainer: { alignItems: "center", justifyContent: "center", padding: 40, marginTop: 40 },
+  emptyText: { color: "#FFFFFF", fontSize: 18, fontWeight: "bold", marginTop: 16 },
+  emptySubtext: { color: "#999", fontSize: 14, textAlign: "center", marginTop: 8, marginBottom: 24 },
 });
 
-export default EventsScreen;
+export default MyEventsScreen;

--- a/app/(athlete)/(tabs)/home.tsx
+++ b/app/(athlete)/(tabs)/home.tsx
@@ -97,8 +97,15 @@ export default function AthleteHome() {
       label: "Events",
       route: "/screens/events",
       icon: "ticket",
-      description: "See what's happening at RISE",
+      description: "Find & register for events",
       colors: ["#8E2DE2", "#4A00E0"] as [string, string],
+    },
+    {
+      label: "My Events",
+      route: "/screens/my-events",
+      icon: "calendar-check",
+      description: "Events you're registered for",
+      colors: ["#2C3E50", "#3498DB"] as [string, string],
     },
     {
       label: "Membership",

--- a/app/(athlete)/_layout.tsx
+++ b/app/(athlete)/_layout.tsx
@@ -11,6 +11,7 @@ export default function AthleteLayout() {
       {/* IMPORTANT: Removed presentation: "modal" to allow detail pages to properly display */}
       {/* Modal presentation was causing Events page to stay on top even when navigating to details */}
       <Stack.Screen name="screens/events" options={{ headerShown: false }} />
+      <Stack.Screen name="screens/my-events" options={{ headerShown: false }} />
       <Stack.Screen name="screens/membership/index" options={{ headerShown: false }} />
       <Stack.Screen name="screens/booking-options/Courts" options={{ headerShown: false }} />
       <Stack.Screen name="screens/booking-options/CourtsideKutz" options={{ headerShown: false }} />

--- a/app/(athlete)/screens/my-events.tsx
+++ b/app/(athlete)/screens/my-events.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   View, Text, FlatList, TouchableOpacity, Image,
   StyleSheet, RefreshControl, ActivityIndicator
@@ -7,41 +7,42 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { useDispatch, useSelector } from "react-redux";
-import { fetchEvents } from "@/store/slices/eventsSlice";
+import { useSelector } from "react-redux";
 import type { RootState } from "@/store";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import dayjs from "dayjs";
 import images from "@/constants/images";
 import { resolveImageSource } from "@/utils/imageSource";
-import Constants from "expo-constants";
+import axios from "axios";
+import { API_URL } from "@/utils/api";
 
-export interface Event {
+interface MyEvent {
   id: string;
   title: string;
   date: string;
   time: string;
   location: string;
   image: string;
-  type: "game" | "match" | "practice" | "course" | "other";
-  program?: { 
+  description: string;
+  program?: {
     id: string;
+    name?: string;
+    type?: string;
     photo_url?: string;
+    description?: string;
   };
 }
 
-
-const EventsScreen: React.FC = () => {
-  const [events, setEvents] = useState<Event[]>([]);
-  const [filteredEvents, setFilteredEvents] = useState<Event[]>([]);
+const MyEventsScreen: React.FC = () => {
+  const [events, setEvents] = useState<MyEvent[]>([]);
+  const [filteredEvents, setFilteredEvents] = useState<MyEvent[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [refreshing, setRefreshing] = useState<boolean>(false);
   const [activeFilter, setActiveFilter] = useState<string>("All");
   const [selectedMonth, setSelectedMonth] = useState<dayjs.Dayjs>(dayjs());
   const router = useRouter();
-  const dispatch = useDispatch();
   const user = useSelector((state: RootState) => state.user.data);
-  const reduxEvents = useSelector((state: RootState) => state.events);
+  const hasFetchedRef = useRef(false);
 
   const getToken = useCallback(async () => {
     let token = user?.token;
@@ -52,74 +53,90 @@ const EventsScreen: React.FC = () => {
     return token;
   }, [user?.token]);
 
-  const fetchData = useCallback(async () => {
-    const token = await getToken();
-    if (!token) return;
-    dispatch(fetchEvents(token) as any);
-  }, [dispatch, getToken]);
+  const fetchMyEvents = useCallback(async () => {
+    try {
+      const token = await getToken();
+      if (!token) return;
 
-  useEffect(() => {
-    setLoading(true);
-    fetchData().finally(() => {
-      setLoading(false);
-      setRefreshing(false);
-    });
-  }, [fetchData]);
-
-  useEffect(() => {
-    const allEvents: Event[] = [];
-    const seenEventIds = new Set<string>();
-
-    // Convert Redux events
-    // All items from the events API are "events" - they should navigate to event-details
-    Object.values(reduxEvents.byDate).forEach((eventGroup: any[]) => {
-      eventGroup.forEach((event) => {
-        // ✅ Validate event ID exists and is unique
-        if (event.id && !seenEventIds.has(event.id)) {
-          // ✅ Validate date before adding to prevent "Invalid Date"
-          const eventDate = dayjs(event.date);
-          if (eventDate.isValid()) {
-            seenEventIds.add(event.id);
-            allEvents.push({
-              id: event.id,
-              title: event.title || "Untitled Event",
-              date: eventDate.format("YYYY-MM-DD"),
-              time: event.time || "TBD",
-              location: event.location || "TBD",
-              image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
-              // Always use "other" for events from the events API - they should go to event-details
-              // The visual "type" from the slice is just for display, not navigation
-              type: "other",
-              program: event.program?.id ? {
-                id: event.program.id,
-                photo_url: event.program.photo_url
-              } : undefined,
-            });
-          } else {
-            console.warn(`⚠️ Invalid date for event ${event.id}: ${event.date}`);
-          }
-        } else if (!event.id) {
-          console.warn(`⚠️ Event missing ID, skipping:`, event);
-        }
+      const response = await axios.get(`${API_URL}/secure/schedule`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
+
+      const { events: rawEvents } = response.data;
+      const processedEvents: MyEvent[] = [];
+
+      if (rawEvents && Array.isArray(rawEvents)) {
+        rawEvents.forEach((event: any) => {
+          // Parse date from start_at
+          let eventDate = event.date;
+          if (!eventDate && event.start_at) {
+            if (event.start_at.includes('T')) {
+              eventDate = event.start_at.split('T')[0];
+            } else {
+              eventDate = event.start_at.split(' ')[0];
+            }
+          }
+
+          // Validate date
+          const parsedDate = dayjs(eventDate);
+          if (!parsedDate.isValid()) {
+            console.warn(`Invalid date for event ${event.id}: ${eventDate}`);
+            return;
+          }
+
+          // Parse time
+          let formattedTime = "TBD";
+          if (event.start_at) {
+            try {
+              const date = new Date(event.start_at);
+              if (!isNaN(date.getTime())) {
+                formattedTime = date.toLocaleTimeString('en-US', {
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true
+                });
+              }
+            } catch (e) {
+              formattedTime = "TBD";
+            }
+          }
+
+          processedEvents.push({
+            id: event.id,
+            title: event.program?.name || event.name || event.title || "Event",
+            date: parsedDate.format("YYYY-MM-DD"),
+            time: formattedTime,
+            location: (typeof event.location === 'object'
+              ? event.location?.name || event.location?.address
+              : event.location) || "TBD",
+            image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+            description: event.program?.description || event.description || "",
+            program: event.program,
+          });
+        });
+      }
+
+      // Sort chronologically
+      const sortedEvents = processedEvents.sort((a, b) => {
+        return new Date(a.date).getTime() - new Date(b.date).getTime();
+      });
+
+      setEvents(sortedEvents);
+    } catch (error: any) {
+      console.error("Error fetching my events:", error);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    // Only fetch once on mount to prevent infinite loops
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+
+    setLoading(true);
+    fetchMyEvents().finally(() => {
+      setLoading(false);
     });
-
-
-    // Note: Matches are NOT included here - they are viewed from the Matches tab
-    // This Events screen only shows events from the events API
-
-    // Sort events chronologically (earliest date first)
-    const sortedEvents = allEvents.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    // Limit to 100 most recent/upcoming events for performance
-    const limitedEvents = sortedEvents.slice(0, 100);
-
-    setEvents(limitedEvents);
-  }, [reduxEvents.byDate]);
+  }, []);
 
   useEffect(() => {
     filterEvents(activeFilter, selectedMonth);
@@ -127,49 +144,7 @@ const EventsScreen: React.FC = () => {
 
   const onRefresh = () => {
     setRefreshing(true);
-    fetchData().finally(() => setRefreshing(false));
-  };
-
-  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
-    let filtered = events;
-
-    // First filter by month
-    const monthStart = month.startOf("month");
-    const monthEnd = month.endOf("month");
-    filtered = events.filter(event => {
-      const eventDate = dayjs(event.date);
-      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
-    });
-
-    // Then apply status filter
-    if (filter === "All") {
-      // "All" shows only today and future events (no past events) for the selected month
-      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
-    } else {
-      // Map UI filter labels to status values
-      const statusMapping: Record<string, string> = {
-        "Upcoming": "Upcoming",
-        "Today": "Today",
-        "Past": "Past"
-      };
-      const backendStatus = statusMapping[filter] || filter;
-      filtered = filtered.filter(event => getEventStatus(event.date) === backendStatus);
-    }
-
-    // Sort chronologically (earliest date first for upcoming, most recent first for past)
-    const sortedFiltered = filtered.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-
-      if (filter === "Past") {
-        // For past events, show most recent first
-        return dateB.getTime() - dateA.getTime();
-      }
-      // For upcoming/all, show earliest first
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    setFilteredEvents(sortedFiltered);
+    fetchMyEvents().finally(() => setRefreshing(false));
   };
 
   const getEventStatus = (date: string) => {
@@ -181,6 +156,37 @@ const EventsScreen: React.FC = () => {
     return "Upcoming";
   };
 
+  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
+    let filtered = events;
+
+    // Filter by month
+    const monthStart = month.startOf("month");
+    const monthEnd = month.endOf("month");
+    filtered = events.filter(event => {
+      const eventDate = dayjs(event.date);
+      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
+    });
+
+    // Apply status filter
+    if (filter === "All") {
+      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
+    } else {
+      filtered = filtered.filter(event => getEventStatus(event.date) === filter);
+    }
+
+    // Sort
+    const sortedFiltered = filtered.sort((a, b) => {
+      const dateA = new Date(a.date);
+      const dateB = new Date(b.date);
+      if (filter === "Past") {
+        return dateB.getTime() - dateA.getTime();
+      }
+      return dateA.getTime() - dateB.getTime();
+    });
+
+    setFilteredEvents(sortedFiltered);
+  };
+
   const getStatusColor = (status: string) => {
     switch (status) {
       case "Upcoming": return "#FCA311";
@@ -190,7 +196,7 @@ const EventsScreen: React.FC = () => {
     }
   };
 
-  const renderEventItem = ({ item }: { item: Event }) => {
+  const renderEventItem = ({ item }: { item: MyEvent }) => {
     const status = getEventStatus(item.date);
     const statusColor = getStatusColor(status);
 
@@ -199,17 +205,11 @@ const EventsScreen: React.FC = () => {
         style={styles.eventCard}
         activeOpacity={0.9}
         onPress={() => {
-          // All events from this screen go to event-details
-          // (Matches are viewed from the Matches tab, not here)
           router.push({
             pathname: "/screens/event-details/[id]",
-            params: {
-              id: item.id,
-              source: "homepage",
-            },
+            params: { id: item.id, source: "my-events" },
           });
         }}
-
       >
         <Image
           source={resolveImageSource(item.image || item.program?.photo_url, images.event)}
@@ -226,7 +226,7 @@ const EventsScreen: React.FC = () => {
           <View style={styles.eventInfo}>
             <View style={styles.infoRow}>
               <Ionicons name="calendar-outline" size={16} color="#FCA311" style={styles.infoIcon} />
-              <Text style={styles.infoText}>{item.date}</Text>
+              <Text style={styles.infoText}>{dayjs(item.date).format("MMM D, YYYY")}</Text>
             </View>
             <View style={styles.infoRow}>
               <Ionicons name="time-outline" size={16} color="#FCA311" style={styles.infoIcon} />
@@ -243,7 +243,7 @@ const EventsScreen: React.FC = () => {
   };
 
   const renderMonthSelector = () => {
-    const canGoBack = selectedMonth.isAfter(dayjs().subtract(1, "month"), "month");
+    const canGoBack = selectedMonth.isAfter(dayjs().subtract(3, "month"), "month");
     const canGoForward = selectedMonth.isBefore(dayjs().add(6, "months"), "month");
 
     return (
@@ -290,17 +290,18 @@ const EventsScreen: React.FC = () => {
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
       <Ionicons name="calendar-outline" size={50} color="#FCA311" />
-      <Text style={styles.emptyText}>No events found</Text>
+      <Text style={styles.emptyText}>No registered events</Text>
       <Text style={styles.emptySubtext}>
         {activeFilter !== "All"
-          ? `There are no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
-          : `No upcoming events in ${selectedMonth.format("MMMM YYYY")}`}
+          ? `You have no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
+          : `You haven't registered for any events yet`}
       </Text>
-      {activeFilter !== "All" && (
-        <TouchableOpacity style={styles.resetButton} onPress={() => setActiveFilter("All")}>
-          <Text style={styles.resetButtonText}>Show All Events</Text>
-        </TouchableOpacity>
-      )}
+      <TouchableOpacity
+        style={styles.browseButton}
+        onPress={() => router.push("/screens/events")}
+      >
+        <Text style={styles.browseButtonText}>Browse Events</Text>
+      </TouchableOpacity>
     </View>
   );
 
@@ -322,19 +323,18 @@ const EventsScreen: React.FC = () => {
           <Ionicons name="chevron-back" size={24} color="#F0F0F0" />
         </TouchableOpacity>
         <View style={styles.headerTextContainer}>
-          <Text style={styles.headerTitle}>Events</Text>
-          <Text style={styles.headerSubtitle}>Find & register for events</Text>
+          <Text style={styles.headerTitle}>My Events</Text>
+          <Text style={styles.headerSubtitle}>Events you're registered for</Text>
         </View>
         <View style={{ width: 40 }} />
       </View>
       {renderMonthSelector()}
       {renderFilterChips()}
 
-      {/* Info Section */}
       {!loading && events.length > 0 && (
         <View style={styles.infoContainer}>
-          <Text style={styles.infoText}>
-            Showing {filteredEvents.length} of {events.length} events • Sorted by date
+          <Text style={styles.countText}>
+            Showing {filteredEvents.length} of {events.length} registered events
           </Text>
         </View>
       )}
@@ -342,7 +342,7 @@ const EventsScreen: React.FC = () => {
       {loading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#FCA311" />
-          <Text style={styles.loadingText}>Loading events...</Text>
+          <Text style={styles.loadingText}>Loading your events...</Text>
         </View>
       ) : (
         <FlatList
@@ -365,7 +365,6 @@ const EventsScreen: React.FC = () => {
     </SafeAreaView>
   );
 };
-
 
 const styles = StyleSheet.create({
   container: {
@@ -463,6 +462,7 @@ const styles = StyleSheet.create({
   listContent: {
     padding: 20,
     paddingTop: 5,
+    paddingBottom: 100,
   },
   eventCard: {
     backgroundColor: "#1A1A1A",
@@ -470,10 +470,7 @@ const styles = StyleSheet.create({
     overflow: "hidden",
     marginBottom: 20,
     shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 3.84,
     elevation: 5,
@@ -518,13 +515,17 @@ const styles = StyleSheet.create({
   infoIcon: {
     marginRight: 8,
   },
+  infoText: {
+    color: "#999",
+    fontSize: 14,
+  },
   infoContainer: {
     paddingHorizontal: 20,
     paddingVertical: 8,
     borderBottomWidth: 1,
     borderBottomColor: "#222",
   },
-  infoText: {
+  countText: {
     color: "#999",
     fontSize: 12,
     textAlign: "center",
@@ -548,16 +549,17 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 24,
   },
-  resetButton: {
-    backgroundColor: "rgba(252, 163, 17, 0.2)",
+  browseButton: {
+    backgroundColor: "#FCA311",
     paddingVertical: 12,
-    paddingHorizontal: 20,
+    paddingHorizontal: 24,
     borderRadius: 8,
   },
-  resetButtonText: {
-    color: "#FCA311",
+  browseButtonText: {
+    color: "#000",
     fontWeight: "bold",
+    fontSize: 14,
   },
 });
 
-export default EventsScreen;
+export default MyEventsScreen;

--- a/app/(coach)/(tabs)/coachHome.tsx
+++ b/app/(coach)/(tabs)/coachHome.tsx
@@ -91,6 +91,13 @@ export default function CoachHomeScreen() {
       colors: ["#8E2DE2", "#4A00E0"] as [string, string],
     },
     {
+      label: "My Events",
+      route: "/(coach)/screens/my-events",
+      icon: "calendar-day",
+      description: "Events you're registered for",
+      colors: ["#2C3E50", "#3498DB"] as [string, string],
+    },
+    {
       label: "Match History",
       route: "/(coach)/screens/matchHistory",
       icon: "trophy",

--- a/app/(coach)/_layout.tsx
+++ b/app/(coach)/_layout.tsx
@@ -8,6 +8,7 @@ export default function CoachLayout() {
 
       {/* ✅ Coach-specific modal screens - flattened structure to prevent route group nesting */}
       {/* Only declare screens that exist in app/(coach)/screens/ directory */}
+      <Stack.Screen name="screens/my-events" options={{ headerShown: false }} />
       <Stack.Screen name="screens/createMatch" options={{ presentation: "modal" }} />
       <Stack.Screen name="screens/matchHistory" options={{ presentation: "modal" }} />
       <Stack.Screen name="screens/selectTeamForRoster" options={{ presentation: "modal" }} />

--- a/app/(coach)/screens/my-events.tsx
+++ b/app/(coach)/screens/my-events.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   View, Text, FlatList, TouchableOpacity, Image,
   StyleSheet, RefreshControl, ActivityIndicator
@@ -7,41 +7,42 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { useDispatch, useSelector } from "react-redux";
-import { fetchEvents } from "@/store/slices/eventsSlice";
+import { useSelector } from "react-redux";
 import type { RootState } from "@/store";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import dayjs from "dayjs";
 import images from "@/constants/images";
 import { resolveImageSource } from "@/utils/imageSource";
-import Constants from "expo-constants";
+import axios from "axios";
+import { API_URL } from "@/utils/api";
 
-export interface Event {
+interface MyEvent {
   id: string;
   title: string;
   date: string;
   time: string;
   location: string;
   image: string;
-  type: "game" | "match" | "practice" | "course" | "other";
-  program?: { 
+  description: string;
+  program?: {
     id: string;
+    name?: string;
+    type?: string;
     photo_url?: string;
+    description?: string;
   };
 }
 
-
-const EventsScreen: React.FC = () => {
-  const [events, setEvents] = useState<Event[]>([]);
-  const [filteredEvents, setFilteredEvents] = useState<Event[]>([]);
+const MyEventsScreen: React.FC = () => {
+  const [events, setEvents] = useState<MyEvent[]>([]);
+  const [filteredEvents, setFilteredEvents] = useState<MyEvent[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [refreshing, setRefreshing] = useState<boolean>(false);
   const [activeFilter, setActiveFilter] = useState<string>("All");
   const [selectedMonth, setSelectedMonth] = useState<dayjs.Dayjs>(dayjs());
   const router = useRouter();
-  const dispatch = useDispatch();
   const user = useSelector((state: RootState) => state.user.data);
-  const reduxEvents = useSelector((state: RootState) => state.events);
+  const hasFetchedRef = useRef(false);
 
   const getToken = useCallback(async () => {
     let token = user?.token;
@@ -52,74 +53,84 @@ const EventsScreen: React.FC = () => {
     return token;
   }, [user?.token]);
 
-  const fetchData = useCallback(async () => {
-    const token = await getToken();
-    if (!token) return;
-    dispatch(fetchEvents(token) as any);
-  }, [dispatch, getToken]);
+  const fetchMyEvents = useCallback(async () => {
+    try {
+      const token = await getToken();
+      if (!token) return;
 
-  useEffect(() => {
-    setLoading(true);
-    fetchData().finally(() => {
-      setLoading(false);
-      setRefreshing(false);
-    });
-  }, [fetchData]);
-
-  useEffect(() => {
-    const allEvents: Event[] = [];
-    const seenEventIds = new Set<string>();
-
-    // Convert Redux events
-    // All items from the events API are "events" - they should navigate to event-details
-    Object.values(reduxEvents.byDate).forEach((eventGroup: any[]) => {
-      eventGroup.forEach((event) => {
-        // ✅ Validate event ID exists and is unique
-        if (event.id && !seenEventIds.has(event.id)) {
-          // ✅ Validate date before adding to prevent "Invalid Date"
-          const eventDate = dayjs(event.date);
-          if (eventDate.isValid()) {
-            seenEventIds.add(event.id);
-            allEvents.push({
-              id: event.id,
-              title: event.title || "Untitled Event",
-              date: eventDate.format("YYYY-MM-DD"),
-              time: event.time || "TBD",
-              location: event.location || "TBD",
-              image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
-              // Always use "other" for events from the events API - they should go to event-details
-              // The visual "type" from the slice is just for display, not navigation
-              type: "other",
-              program: event.program?.id ? {
-                id: event.program.id,
-                photo_url: event.program.photo_url
-              } : undefined,
-            });
-          } else {
-            console.warn(`⚠️ Invalid date for event ${event.id}: ${event.date}`);
-          }
-        } else if (!event.id) {
-          console.warn(`⚠️ Event missing ID, skipping:`, event);
-        }
+      const response = await axios.get(`${API_URL}/secure/schedule`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
+
+      const { events: rawEvents } = response.data;
+      const processedEvents: MyEvent[] = [];
+
+      if (rawEvents && Array.isArray(rawEvents)) {
+        rawEvents.forEach((event: any) => {
+          let eventDate = event.date;
+          if (!eventDate && event.start_at) {
+            if (event.start_at.includes('T')) {
+              eventDate = event.start_at.split('T')[0];
+            } else {
+              eventDate = event.start_at.split(' ')[0];
+            }
+          }
+
+          const parsedDate = dayjs(eventDate);
+          if (!parsedDate.isValid()) {
+            return;
+          }
+
+          let formattedTime = "TBD";
+          if (event.start_at) {
+            try {
+              const date = new Date(event.start_at);
+              if (!isNaN(date.getTime())) {
+                formattedTime = date.toLocaleTimeString('en-US', {
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true
+                });
+              }
+            } catch (e) {
+              formattedTime = "TBD";
+            }
+          }
+
+          processedEvents.push({
+            id: event.id,
+            title: event.program?.name || event.name || event.title || "Event",
+            date: parsedDate.format("YYYY-MM-DD"),
+            time: formattedTime,
+            location: (typeof event.location === 'object'
+              ? event.location?.name || event.location?.address
+              : event.location) || "TBD",
+            image: event.program?.photo_url || "https://images.unsplash.com/photo-1504450758481-7338eba7524a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+            description: event.program?.description || event.description || "",
+            program: event.program,
+          });
+        });
+      }
+
+      const sortedEvents = processedEvents.sort((a, b) => {
+        return new Date(a.date).getTime() - new Date(b.date).getTime();
+      });
+
+      setEvents(sortedEvents);
+    } catch (error: any) {
+      console.error("Error fetching my events:", error);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    if (hasFetchedRef.current) return;
+    hasFetchedRef.current = true;
+
+    setLoading(true);
+    fetchMyEvents().finally(() => {
+      setLoading(false);
     });
-
-
-    // Note: Matches are NOT included here - they are viewed from the Matches tab
-    // This Events screen only shows events from the events API
-
-    // Sort events chronologically (earliest date first)
-    const sortedEvents = allEvents.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    // Limit to 100 most recent/upcoming events for performance
-    const limitedEvents = sortedEvents.slice(0, 100);
-
-    setEvents(limitedEvents);
-  }, [reduxEvents.byDate]);
+  }, []);
 
   useEffect(() => {
     filterEvents(activeFilter, selectedMonth);
@@ -127,49 +138,7 @@ const EventsScreen: React.FC = () => {
 
   const onRefresh = () => {
     setRefreshing(true);
-    fetchData().finally(() => setRefreshing(false));
-  };
-
-  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
-    let filtered = events;
-
-    // First filter by month
-    const monthStart = month.startOf("month");
-    const monthEnd = month.endOf("month");
-    filtered = events.filter(event => {
-      const eventDate = dayjs(event.date);
-      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
-    });
-
-    // Then apply status filter
-    if (filter === "All") {
-      // "All" shows only today and future events (no past events) for the selected month
-      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
-    } else {
-      // Map UI filter labels to status values
-      const statusMapping: Record<string, string> = {
-        "Upcoming": "Upcoming",
-        "Today": "Today",
-        "Past": "Past"
-      };
-      const backendStatus = statusMapping[filter] || filter;
-      filtered = filtered.filter(event => getEventStatus(event.date) === backendStatus);
-    }
-
-    // Sort chronologically (earliest date first for upcoming, most recent first for past)
-    const sortedFiltered = filtered.sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-
-      if (filter === "Past") {
-        // For past events, show most recent first
-        return dateB.getTime() - dateA.getTime();
-      }
-      // For upcoming/all, show earliest first
-      return dateA.getTime() - dateB.getTime();
-    });
-
-    setFilteredEvents(sortedFiltered);
+    fetchMyEvents().finally(() => setRefreshing(false));
   };
 
   const getEventStatus = (date: string) => {
@@ -181,6 +150,34 @@ const EventsScreen: React.FC = () => {
     return "Upcoming";
   };
 
+  const filterEvents = (filter: string, month: dayjs.Dayjs) => {
+    let filtered = events;
+
+    const monthStart = month.startOf("month");
+    const monthEnd = month.endOf("month");
+    filtered = events.filter(event => {
+      const eventDate = dayjs(event.date);
+      return eventDate.isAfter(monthStart.subtract(1, "day")) && eventDate.isBefore(monthEnd.add(1, "day"));
+    });
+
+    if (filter === "All") {
+      filtered = filtered.filter(event => getEventStatus(event.date) !== "Past");
+    } else {
+      filtered = filtered.filter(event => getEventStatus(event.date) === filter);
+    }
+
+    const sortedFiltered = filtered.sort((a, b) => {
+      const dateA = new Date(a.date);
+      const dateB = new Date(b.date);
+      if (filter === "Past") {
+        return dateB.getTime() - dateA.getTime();
+      }
+      return dateA.getTime() - dateB.getTime();
+    });
+
+    setFilteredEvents(sortedFiltered);
+  };
+
   const getStatusColor = (status: string) => {
     switch (status) {
       case "Upcoming": return "#FCA311";
@@ -190,7 +187,7 @@ const EventsScreen: React.FC = () => {
     }
   };
 
-  const renderEventItem = ({ item }: { item: Event }) => {
+  const renderEventItem = ({ item }: { item: MyEvent }) => {
     const status = getEventStatus(item.date);
     const statusColor = getStatusColor(status);
 
@@ -199,17 +196,11 @@ const EventsScreen: React.FC = () => {
         style={styles.eventCard}
         activeOpacity={0.9}
         onPress={() => {
-          // All events from this screen go to event-details
-          // (Matches are viewed from the Matches tab, not here)
           router.push({
             pathname: "/screens/event-details/[id]",
-            params: {
-              id: item.id,
-              source: "homepage",
-            },
+            params: { id: item.id, source: "my-events" },
           });
         }}
-
       >
         <Image
           source={resolveImageSource(item.image || item.program?.photo_url, images.event)}
@@ -226,7 +217,7 @@ const EventsScreen: React.FC = () => {
           <View style={styles.eventInfo}>
             <View style={styles.infoRow}>
               <Ionicons name="calendar-outline" size={16} color="#FCA311" style={styles.infoIcon} />
-              <Text style={styles.infoText}>{item.date}</Text>
+              <Text style={styles.infoText}>{dayjs(item.date).format("MMM D, YYYY")}</Text>
             </View>
             <View style={styles.infoRow}>
               <Ionicons name="time-outline" size={16} color="#FCA311" style={styles.infoIcon} />
@@ -243,7 +234,7 @@ const EventsScreen: React.FC = () => {
   };
 
   const renderMonthSelector = () => {
-    const canGoBack = selectedMonth.isAfter(dayjs().subtract(1, "month"), "month");
+    const canGoBack = selectedMonth.isAfter(dayjs().subtract(3, "month"), "month");
     const canGoForward = selectedMonth.isBefore(dayjs().add(6, "months"), "month");
 
     return (
@@ -290,17 +281,12 @@ const EventsScreen: React.FC = () => {
   const renderEmptyState = () => (
     <View style={styles.emptyContainer}>
       <Ionicons name="calendar-outline" size={50} color="#FCA311" />
-      <Text style={styles.emptyText}>No events found</Text>
+      <Text style={styles.emptyText}>No registered events</Text>
       <Text style={styles.emptySubtext}>
         {activeFilter !== "All"
-          ? `There are no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
-          : `No upcoming events in ${selectedMonth.format("MMMM YYYY")}`}
+          ? `You have no ${activeFilter.toLowerCase()} events in ${selectedMonth.format("MMMM YYYY")}`
+          : `You haven't registered for any events yet`}
       </Text>
-      {activeFilter !== "All" && (
-        <TouchableOpacity style={styles.resetButton} onPress={() => setActiveFilter("All")}>
-          <Text style={styles.resetButtonText}>Show All Events</Text>
-        </TouchableOpacity>
-      )}
     </View>
   );
 
@@ -315,26 +301,25 @@ const EventsScreen: React.FC = () => {
             if (canGoBack) {
               router.back();
             } else {
-              router.replace("/(athlete)/(tabs)/home");
+              router.replace("/(coach)/(tabs)/coachHome");
             }
           }}
         >
           <Ionicons name="chevron-back" size={24} color="#F0F0F0" />
         </TouchableOpacity>
         <View style={styles.headerTextContainer}>
-          <Text style={styles.headerTitle}>Events</Text>
-          <Text style={styles.headerSubtitle}>Find & register for events</Text>
+          <Text style={styles.headerTitle}>My Events</Text>
+          <Text style={styles.headerSubtitle}>Events you're registered for</Text>
         </View>
         <View style={{ width: 40 }} />
       </View>
       {renderMonthSelector()}
       {renderFilterChips()}
 
-      {/* Info Section */}
       {!loading && events.length > 0 && (
         <View style={styles.infoContainer}>
-          <Text style={styles.infoText}>
-            Showing {filteredEvents.length} of {events.length} events • Sorted by date
+          <Text style={styles.countText}>
+            Showing {filteredEvents.length} of {events.length} registered events
           </Text>
         </View>
       )}
@@ -342,7 +327,7 @@ const EventsScreen: React.FC = () => {
       {loading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#FCA311" />
-          <Text style={styles.loadingText}>Loading events...</Text>
+          <Text style={styles.loadingText}>Loading your events...</Text>
         </View>
       ) : (
         <FlatList
@@ -366,12 +351,8 @@ const EventsScreen: React.FC = () => {
   );
 };
 
-
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#0C0B0B",
-  },
+  container: { flex: 1, backgroundColor: "#0C0B0B" },
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -389,20 +370,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  headerTextContainer: {
-    flex: 1,
-    alignItems: "center",
-  },
-  headerTitle: {
-    fontSize: 22,
-    fontWeight: "bold",
-    color: "#FFFFFF",
-  },
-  headerSubtitle: {
-    fontSize: 12,
-    color: "#999",
-    marginTop: 2,
-  },
+  headerTextContainer: { flex: 1, alignItems: "center" },
+  headerTitle: { fontSize: 22, fontWeight: "bold", color: "#FFFFFF" },
+  headerSubtitle: { fontSize: 12, color: "#999", marginTop: 2 },
   monthSelectorContainer: {
     flexDirection: "row",
     alignItems: "center",
@@ -412,12 +382,8 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: "#222",
   },
-  monthArrow: {
-    padding: 8,
-  },
-  monthArrowDisabled: {
-    opacity: 0.5,
-  },
+  monthArrow: { padding: 8 },
+  monthArrowDisabled: { opacity: 0.5 },
   monthText: {
     fontSize: 18,
     fontWeight: "600",
@@ -426,11 +392,7 @@ const styles = StyleSheet.create({
     minWidth: 150,
     textAlign: "center",
   },
-  filtersContainer: {
-    flexDirection: "row",
-    paddingHorizontal: 20,
-    paddingVertical: 15,
-  },
+  filtersContainer: { flexDirection: "row", paddingHorizontal: 20, paddingVertical: 15 },
   filterChip: {
     paddingHorizontal: 16,
     paddingVertical: 8,
@@ -438,126 +400,43 @@ const styles = StyleSheet.create({
     backgroundColor: "#1A1A1A",
     marginRight: 10,
   },
-  activeFilterChip: {
-    backgroundColor: "rgba(252, 163, 17, 0.2)",
-  },
-  filterChipText: {
-    color: "#999",
-    fontWeight: "500",
-    fontSize: 14,
-  },
-  activeFilterChipText: {
-    color: "#FCA311",
-    fontWeight: "600",
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  loadingText: {
-    color: "#999",
-    marginTop: 12,
-    fontSize: 16,
-  },
-  listContent: {
-    padding: 20,
-    paddingTop: 5,
-  },
+  activeFilterChip: { backgroundColor: "rgba(252, 163, 17, 0.2)" },
+  filterChipText: { color: "#999", fontWeight: "500", fontSize: 14 },
+  activeFilterChipText: { color: "#FCA311", fontWeight: "600" },
+  loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
+  loadingText: { color: "#999", marginTop: 12, fontSize: 16 },
+  listContent: { padding: 20, paddingTop: 5, paddingBottom: 100 },
   eventCard: {
     backgroundColor: "#1A1A1A",
     borderRadius: 16,
     overflow: "hidden",
     marginBottom: 20,
     shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
+    shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 3.84,
     elevation: 5,
   },
-  eventImage: {
-    width: "100%",
-    height: 160,
-  },
-  eventDetails: {
-    padding: 16,
-  },
+  eventImage: { width: "100%", height: 160 },
+  eventDetails: { padding: 16 },
   eventHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "flex-start",
     marginBottom: 12,
   },
-  eventTitle: {
-    fontSize: 18,
-    fontWeight: "bold",
-    color: "#FFFFFF",
-    flex: 1,
-    marginRight: 8,
-  },
-  statusBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 12,
-  },
-  statusText: {
-    fontSize: 12,
-    fontWeight: "bold",
-  },
-  eventInfo: {
-    marginTop: 4,
-  },
-  infoRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  infoIcon: {
-    marginRight: 8,
-  },
-  infoContainer: {
-    paddingHorizontal: 20,
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: "#222",
-  },
-  infoText: {
-    color: "#999",
-    fontSize: 12,
-    textAlign: "center",
-  },
-  emptyContainer: {
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 40,
-    marginTop: 40,
-  },
-  emptyText: {
-    color: "#FFFFFF",
-    fontSize: 18,
-    fontWeight: "bold",
-    marginTop: 16,
-  },
-  emptySubtext: {
-    color: "#999",
-    fontSize: 14,
-    textAlign: "center",
-    marginTop: 8,
-    marginBottom: 24,
-  },
-  resetButton: {
-    backgroundColor: "rgba(252, 163, 17, 0.2)",
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-  },
-  resetButtonText: {
-    color: "#FCA311",
-    fontWeight: "bold",
-  },
+  eventTitle: { fontSize: 18, fontWeight: "bold", color: "#FFFFFF", flex: 1, marginRight: 8 },
+  statusBadge: { paddingHorizontal: 10, paddingVertical: 5, borderRadius: 12 },
+  statusText: { fontSize: 12, fontWeight: "bold" },
+  eventInfo: { marginTop: 4 },
+  infoRow: { flexDirection: "row", alignItems: "center", marginBottom: 8 },
+  infoIcon: { marginRight: 8 },
+  infoText: { color: "#999", fontSize: 14 },
+  infoContainer: { paddingHorizontal: 20, paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: "#222" },
+  countText: { color: "#999", fontSize: 12, textAlign: "center" },
+  emptyContainer: { alignItems: "center", justifyContent: "center", padding: 40, marginTop: 40 },
+  emptyText: { color: "#FFFFFF", fontSize: 18, fontWeight: "bold", marginTop: 16 },
+  emptySubtext: { color: "#999", fontSize: 14, textAlign: "center", marginTop: 8, marginBottom: 24 },
 });
 
-export default EventsScreen;
+export default MyEventsScreen;

--- a/components/calendar/EventListContainer.tsx
+++ b/components/calendar/EventListContainer.tsx
@@ -29,6 +29,8 @@ interface EventListContainerProps {
   error?: string | null
   onRetry?: () => void
   emptyMessage?: string
+  emptyActionLabel?: string
+  onEmptyAction?: () => void
   children?: React.ReactNode
 }
 
@@ -96,6 +98,8 @@ const EventListContainer: React.FC<EventListContainerProps> = ({
   error = null,
   onRetry,
   emptyMessage = "There are no events scheduled for this day.",
+  emptyActionLabel,
+  onEmptyAction,
   children,
 }) => {
   const insets = useSafeAreaInsets()
@@ -178,7 +182,15 @@ const EventListContainer: React.FC<EventListContainerProps> = ({
               flexGrow: 1,
               minHeight: data.length === 0 ? 200 : undefined,
             }}
-            ListEmptyComponent={<EmptyState icon="calendar-xmark" title="No Events" message={emptyMessage} />}
+            ListEmptyComponent={
+              <EmptyState
+                icon="calendar-xmark"
+                title="No Events"
+                message={emptyMessage}
+                actionLabel={emptyActionLabel}
+                onAction={onEmptyAction}
+              />
+            }
             maxToRenderPerBatch={10}
             windowSize={5}
             initialNumToRender={10}

--- a/components/shared/SharedCalendar.tsx
+++ b/components/shared/SharedCalendar.tsx
@@ -4,12 +4,14 @@
 import type React from "react"
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react"
-import { View, Animated, InteractionManager } from "react-native"
+import { View, Animated } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { StatusBar } from "expo-status-bar"
+import { useRouter } from "expo-router"
 import dayjs from "dayjs"
 import { useDispatch, useSelector } from "react-redux"
 import type { RootState } from "@/store"
+import AsyncStorage from "@react-native-async-storage/async-storage"
 import { fetchEvents, clearEvents } from "@/store/slices/eventsSlice"
 import { fetchMatches, clearMatches } from "@/store/slices/gamesSlice"
 import type { Match } from "@/store/slices/gamesSlice"
@@ -17,11 +19,10 @@ import { fetchSchedule, clearSchedule, clearScheduleError } from "@/store/slices
 import PageTitle from "@/components/PageTitle"
 import CalendarCard from "@/components/calendar/CalendarCard"
 import EventListContainer from "@/components/calendar/EventListContainer"
-import { useAuth } from "@/utils/auth"
 import Constants from "expo-constants"
 
 interface SharedCalendarProps {
-  userRole: "athlete" | "coach" | "instructor" | "parent"
+  userRole: "athlete" | "coach" | "instructor" | "parent" | "admin" | "super_admin"
   title?: string
   childrenData?: any[]
   embedded?: boolean // New prop to indicate it's embedded in another view
@@ -47,12 +48,20 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
   const [selectedDate, setSelectedDate] = useState<string>(dayjs().format("YYYY-MM-DD"))
   const fadeAnim = useRef(new Animated.Value(0)).current
   const dispatch = useDispatch()
-  const { getValidToken, forceReLogin } = useAuth()
-  const calendarInteractionRef = useRef<ReturnType<typeof InteractionManager.runAfterInteractions> | null>(null)
-  const isMountedRef = useRef(true) // Track component mount state
+  const router = useRouter()
 
   // Get user from Redux store
   const user = useSelector((state: RootState) => state.user.data)
+
+  // Get token reliably from Redux or AsyncStorage
+  const getToken = useCallback(async () => {
+    let token = user?.token
+    if (!token) {
+      const userString = await AsyncStorage.getItem("user")
+      if (userString) token = JSON.parse(userString).token
+    }
+    return token
+  }, [user?.token])
 
   // Get calendar data from Redux store
   const reduxEvents = useSelector((state: RootState) => state.events)
@@ -79,77 +88,40 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
     : null
 
 
-// Fetch calendar data - stable reference without dependencies
-  const fetchCalendarData = useCallback(async (forceRefresh = false) => {
-    // Only proceed if component is still mounted
-    if (!isMountedRef.current) {
-      return
+// Fetch calendar data - simplified pattern matching Events page
+  const fetchData = useCallback(async (forceRefresh = false) => {
+    const token = await getToken()
+    if (!token) return
+
+    // Clear existing data before fetching fresh data
+    if (forceRefresh) {
+      dispatch(clearSchedule())
     }
 
-    if (calendarInteractionRef.current) {
-      calendarInteractionRef.current.cancel()
+    // Try unified schedule endpoint first
+    try {
+      await dispatch(fetchSchedule(token) as any).unwrap()
+    } catch (scheduleErr) {
+      // Fallback to separate endpoints when schedule fails
+      dispatch(clearScheduleError())
+
+      if (forceRefresh) {
+        dispatch(clearEvents())
+        dispatch(clearMatches())
+      }
+
+      dispatch(fetchEvents(token) as any)
+      dispatch(fetchMatches(token) as any)
     }
+  }, [getToken, dispatch])
 
-    calendarInteractionRef.current = InteractionManager.runAfterInteractions(async () => {
-      // Check mount state again after interaction completes
-      if (!isMountedRef.current) {
-        return
-      }
-
-      try {
-        const jwt = await getValidToken()
-
-        if (!jwt) {
-          await forceReLogin("Session expired. Please log in again.")
-          return
-        }
-
-        // Clear existing schedule data before fetching fresh data
-        // This ensures we don't show stale data (e.g., events user is no longer enrolled in)
-        if (forceRefresh) {
-          dispatch(clearSchedule())
-        }
-
-        // Try unified schedule endpoint first
-        try {
-          await dispatch(fetchSchedule(jwt) as any).unwrap()
-        } catch (scheduleErr) {
-          // Only continue with fallback if still mounted
-          if (!isMountedRef.current) {
-            return
-          }
-          // Fallback to separate endpoints when schedule fails
-          // Clear schedule error to prevent UI lockup
-          dispatch(clearScheduleError())
-
-          // Clear events and matches data when force refreshing to remove stale entries
-          if (forceRefresh) {
-            dispatch(clearEvents())
-            dispatch(clearMatches())
-          }
-
-          dispatch(fetchEvents(jwt) as any)
-          dispatch(fetchMatches(jwt) as any)
-        }
-      } catch (err) {
-        if (isMountedRef.current) {
-          console.error("❌ Error fetching calendar data:", err)
-        }
-      }
-    })
-  }, []) // Empty deps - rely on dispatch/getValidToken/forceReLogin closure
-
-  // Memoize the refresh handler - stable reference
-  // Pass true to force refresh and clear stale data
+  // Memoize the refresh handler
   const handleRefresh = useCallback(() => {
-    fetchCalendarData(true)
-  }, []) // Empty deps - fetchCalendarData is stable
+    fetchData(true)
+  }, [fetchData])
 
-  // Animation and initial data fetch - only run once
+  // Animation effect - only run once
   useEffect(() => {
-    // Mark component as mounted
-    isMountedRef.current = true
-
     // Start fade-in animation
     const fadeAnimation = Animated.timing(fadeAnim, {
       toValue: 1,
@@ -158,22 +130,16 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
     })
     fadeAnimation.start()
 
-    fetchCalendarData()
-
     return () => {
-      // Mark component as unmounted
-      isMountedRef.current = false
-
-      // Stop animation to prevent updates during unmount
       fadeAnimation.stop()
       fadeAnim.stopAnimation()
-
-      // Cancel any pending interactions
-      calendarInteractionRef.current?.cancel()
-      calendarInteractionRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Fetch data when component mounts or token changes
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
 
   // Process matches data to organize by date
   const matchesByDate = useMemo(() => {
@@ -209,41 +175,51 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
 
   // Combine all events and matches for the selected date
   const combinedEventsForSelectedDate = useMemo(() => {
-    // If we have schedule data, use it (unified data source)
-    if (reduxSchedule.items.length > 0) {
+    // If schedule fetch succeeded, use schedule data (even if empty)
+    // Only fall back to events/matches if schedule fetch actually FAILED
+    if (reduxSchedule.status === "succeeded") {
       return reduxSchedule.byDate[selectedDate] || []
     }
-    
-    // Fallback to separate events and matches
-    const events = reduxEvents.byDate[selectedDate] || []
-    const matches = matchesByDate[selectedDate] || []
-    
-    return [...events, ...matches]
-  }, [reduxSchedule.byDate, reduxEvents.byDate, matchesByDate, selectedDate])
+
+    // Fallback to separate events and matches only if schedule fetch failed
+    if (reduxSchedule.status === "failed") {
+      const events = reduxEvents.byDate[selectedDate] || []
+      const matches = matchesByDate[selectedDate] || []
+      return [...events, ...matches]
+    }
+
+    // Still loading or idle - return empty
+    return []
+  }, [reduxSchedule.status, reduxSchedule.byDate, reduxEvents.byDate, matchesByDate, selectedDate])
 
   const combinedCalendarEvents = useMemo(() => {
-    // If we have schedule data, use it (unified data source)
-    if (reduxSchedule.items.length > 0) {
+    // If schedule fetch succeeded, use schedule data (even if empty)
+    if (reduxSchedule.status === "succeeded") {
       return reduxSchedule.byDate
-  }
-  
-  // Fallback to separate events and matches
-  const allDates = {
-    ...reduxEvents.byDate,
-    ...matchesByDate,
-  }
+    }
 
-  const combined: Record<string, any[]> = {}
+    // Fallback to separate events and matches only if schedule fetch failed
+    if (reduxSchedule.status === "failed") {
+      const allDates = {
+        ...reduxEvents.byDate,
+        ...matchesByDate,
+      }
 
-  Object.keys(allDates).forEach((date) => {
-    combined[date] = [
-      ...(reduxEvents.byDate[date] || []),
-      ...(matchesByDate[date] || []),
-    ]
-  })
+      const combined: Record<string, any[]> = {}
 
-  return combined
-}, [reduxSchedule.byDate, reduxEvents.byDate, matchesByDate])
+      Object.keys(allDates).forEach((date) => {
+        combined[date] = [
+          ...(reduxEvents.byDate[date] || []),
+          ...(matchesByDate[date] || []),
+        ]
+      })
+
+      return combined
+    }
+
+    // Still loading or idle - return empty
+    return {}
+  }, [reduxSchedule.status, reduxSchedule.byDate, reduxEvents.byDate, matchesByDate])
 
   const windowedCalendarEvents = useMemo(() => {
     const selectedMonth = dayjs(selectedDate).startOf("month")
@@ -271,8 +247,8 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
   const markedDates = useMemo(() => {
     const marked: Record<string, { marked: boolean; dotColor: string }> = {}
 
-    // If we have schedule data, use it (unified data source)
-    if (reduxSchedule.items.length > 0) {
+    // If schedule fetch succeeded, use schedule data (even if empty)
+    if (reduxSchedule.status === "succeeded") {
       Object.keys(reduxSchedule.byDate).forEach((date) => {
         const dayItems = reduxSchedule.byDate[date]
         if (dayItems && dayItems.length > 0) {
@@ -280,7 +256,7 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
           const hasMatches = dayItems.some((item) => item.type === "match")
           const hasEvents = dayItems.some((item) => item.type === "event")
           const hasPractices = dayItems.some((item) => item.type === "practice")
-          
+
           marked[date] = {
             marked: true,
             // Priority: matches (orange) > practices (blue) > events (green)
@@ -288,8 +264,8 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
           }
         }
       })
-    } else {
-      // Fallback to separate events and matches
+    } else if (reduxSchedule.status === "failed") {
+      // Fallback to separate events and matches only if schedule fetch failed
       // Add events from Redux
       Object.keys(reduxEvents.byDate).forEach((date) => {
         if (reduxEvents.byDate[date] && reduxEvents.byDate[date].length > 0) {
@@ -310,9 +286,10 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
         }
       })
     }
+    // If still loading or idle, return empty marked dates
 
     return marked
-  }, [reduxSchedule.byDate, reduxEvents.byDate, matchesByDate])
+  }, [reduxSchedule.status, reduxSchedule.byDate, reduxEvents.byDate, matchesByDate])
 
   // Memoize formatted date
   const formattedDate = useMemo(() => {
@@ -325,7 +302,10 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
       case "parent":
         return `No events scheduled for your children on ${formattedDate}.`
       case "coach":
-        return `No events scheduled for your team on ${formattedDate}.`
+        return `No events on ${formattedDate}.\n\nFeel like you're missing an event? Please speak to the front desk or admin.`
+      case "admin":
+      case "super_admin":
+        return `No events on ${formattedDate}.\n\nFeel like you're missing an event? Please check with a super admin.`
       case "instructor":
         return `No classes or events scheduled for ${formattedDate}.`
       default:
@@ -352,7 +332,9 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
           isLoading={isLoading}
           error={error}
           onRetry={handleRefresh}
-          emptyMessage={emptyStateMessage}
+          emptyMessage={`${emptyStateMessage}\n\nLooking to register for an event? Browse available events to sign up.`}
+          emptyActionLabel="Browse Events"
+          onEmptyAction={() => router.push("/screens/events")}
         />
       </Animated.View>
     )
@@ -381,7 +363,9 @@ const SharedCalendar: React.FC<SharedCalendarProps> = ({
           isLoading={isLoading}
           error={error}
           onRetry={handleRefresh}
-          emptyMessage={emptyStateMessage}
+          emptyMessage={`${emptyStateMessage}\n\nLooking to register for an event? Browse available events to sign up.`}
+          emptyActionLabel="Browse Events"
+          onEmptyAction={() => router.push("/screens/events")}
         />
       </Animated.View>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
This commit introduces a new "My Events" feature across all user roles (athlete, coach, admin) and fixes several issues with the Schedule/Calendar page to improve user experience and clarity.

## New Features

### My Events Screen (All Roles)
- Added new "My Events" screen that shows only events the user is registered for
- Fetches data from `/secure/schedule` API endpoint and filters to show only events
- Includes month selector, filter chips (All, Upcoming, Today, Past), and event cards
- Each role has their own screen with appropriate navigation:
  - Athlete: `/app/(athlete)/screens/my-events.tsx`
  - Coach: `/app/(coach)/screens/my-events.tsx`
  - Admin: `/app/(admin)/screens/my-events.tsx`

### Navigation Tiles
- Added "My Events" GoToCard tile to home screens for all roles
- Blue gradient color (#2C3E50 → #3498DB) to differentiate from other tiles
- Updated "Events" tile description to "Find & register for events" for clarity

### Events Screen Improvements
- Added subtitle "Find & register for events" to the Events screen header
- Helps users understand this is where they browse and register for events

## Bug Fixes

### Schedule Page - Fixed Incorrect Event Display
- Fixed bug where Schedule page would show ALL events after visiting Events page
- Root cause: Fallback logic treated "empty schedule" same as "failed fetch"
- Solution: Now checks `reduxSchedule.status === "succeeded"` instead of `items.length > 0`
- Schedule now correctly shows only registered events (empty if user has none)

### Schedule Page - Fixed Data Loading Issue
- Fixed issue where Schedule page wouldn't load until Events page was visited first
- Removed `InteractionManager` wrapper that was causing delays
- Simplified fetch pattern to match Events page (more reliable token handling)
- Added proper `useEffect` dependency on `user?.token` for automatic refetch

### SharedCalendar - Empty State Messages
- Updated empty state messages for coach/admin roles
- Coach: "No events on [date]. Feel like you're missing an event? Please speak to the front desk or admin."
- Admin: "No events on [date]. Feel like you're missing an event? Please check with a super admin."
- Fixed admin schedule passing incorrect `userRole="athlete"` → now passes `userRole="admin"`

### EventListContainer - Action Button Support
- Added `emptyActionLabel` and `onEmptyAction` props to support action buttons in empty state
- Schedule page now shows "Browse Events" button when empty to guide users

## Files Changed

### New Files
- `app/(athlete)/screens/my-events.tsx` - Athlete My Events screen
- `app/(coach)/screens/my-events.tsx` - Coach My Events screen
- `app/(admin)/screens/my-events.tsx` - Admin My Events screen

### Modified Files
- `app/(athlete)/(tabs)/home.tsx` - Added My Events tile, updated Events description
- `app/(athlete)/_layout.tsx` - Registered my-events screen
- `app/(athlete)/screens/events.tsx` - Added header subtitle
- `app/(coach)/(tabs)/coachHome.tsx` - Added My Events tile
- `app/(coach)/_layout.tsx` - Registered my-events screen
- `app/(admin)/(tabs)/dashboard.tsx` - Added My Events tile
- `app/(admin)/(tabs)/schedule.tsx` - Fixed userRole prop
- `app/(admin)/screens/_layout.tsx` - Registered my-events screen
- `components/calendar/EventListContainer.tsx` - Added empty action props
- `components/shared/SharedCalendar.tsx` - Fixed data loading, empty state messages, status checks

