### PR TITLE
feat: Add mobile session tracking after login

### DIFF
--- a/utils/api/auth.ts
+++ b/utils/api/auth.ts
@@ -3,6 +3,23 @@ import { createUserWithEmailAndPassword, signInWithEmailAndPassword } from "fire
 import { auth } from "@/firebase/firebaseConfig";
 import { API_URL } from "./core/constants";
 
+// 🔹 **Track Mobile Session (called after login to record mobile app usage)**
+export const trackMobileSession = async (jwtToken: string): Promise<void> => {
+  try {
+    await axios.post(`${API_URL}/secure/mobile/session`, {}, {
+      headers: { Authorization: `Bearer ${jwtToken}` }
+    });
+    if (__DEV__) {
+      console.log("✅ Mobile session tracked successfully");
+    }
+  } catch (error: any) {
+    // Don't throw - this is non-critical tracking, shouldn't block login
+    if (__DEV__) {
+      console.warn("⚠️ Failed to track mobile session:", error.response?.data || error.message);
+    }
+  }
+};
+
 type User = {
   id: string;
   email: string;

--- a/utils/api/index.ts
+++ b/utils/api/index.ts
@@ -10,6 +10,7 @@ export {
   resendVerificationEmail,
   registerChild,
   registerUser,
+  trackMobileSession,
 } from './auth';
 
 // Locations

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react"
 import { router } from "expo-router"
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import { loginUser, registerUser, verifyEmail as apiVerifyEmail, resendVerificationEmail as apiResendVerificationEmail } from "./api" // Import API functions
+import { loginUser, registerUser, verifyEmail as apiVerifyEmail, resendVerificationEmail as apiResendVerificationEmail, trackMobileSession } from "./api" // Import API functions
 import { auth } from "@/firebase/firebaseConfig"
 import { GoogleAuthProvider, signInWithCredential, OAuthProvider, onAuthStateChanged, User as FirebaseUser, signOut } from "firebase/auth"
 import * as WebBrowser from "expo-web-browser"
@@ -161,6 +161,11 @@ export const useAuth = () => {
       const userData = await loginUser(email, password)
       dispatch(setReduxUser(userData))
       await saveUserToRedux(userData)
+
+      // Track mobile session for analytics (non-blocking)
+      if (userData.token) {
+        trackMobileSession(userData.token)
+      }
 
       const userRole = userData.role?.toLowerCase()?.trim() || ""
 


### PR DESCRIPTION
Call POST /secure/mobile/session after successful email/password login to track mobile app usage for admin analytics.