### PR TITLE
fix: Remove parent role from signup flow

### DIFF
--- a/components/auth/RoleSelectionModal.tsx
+++ b/components/auth/RoleSelectionModal.tsx
@@ -53,18 +53,6 @@ export const RoleSelectionModal = ({ visible, onClose, onSelectRole, currentRole
                 )}
               </TouchableOpacity>
 
-              <TouchableOpacity style={styles.roleOption} onPress={() => handleRoleSelect("parent")}>
-                <View style={styles.roleIconContainer}>
-                  <FontAwesome5 name="user-friends" size={24} color="#FCA311" />
-                </View>
-                <View style={styles.roleTextContainer}>
-                  <Text style={styles.roleTitle}>Parent</Text>
-                  <Text style={styles.roleDescription}>Manage your child's activities</Text>
-                </View>
-                {currentRole === "parent" && (
-                  <Ionicons name="checkmark-circle" size={24} color="#FCA311" style={styles.checkIcon} />
-                )}
-              </TouchableOpacity>
 
               <TouchableOpacity style={styles.closeModalButton} onPress={onClose}>
                 <Text style={styles.closeModalButtonText}>CLOSE</Text>

--- a/components/auth/SignupStep2Form.tsx
+++ b/components/auth/SignupStep2Form.tsx
@@ -203,8 +203,6 @@ export const SignupStep2Form: React.FC<SignupStep2FormProps> = ({
         return <FontAwesome5 name="basketball-ball" size={18} color="#FCA311" />
       case "coach":
         return <FontAwesome5 name="chalkboard-teacher" size={18} color="#FCA311" />
-      case "parent":
-        return <Ionicons name="people" size={18} color="#FCA311" />
       case "instructor":
         return <MaterialCommunityIcons name="whistle" size={18} color="#FCA311" />
       case "barber":


### PR DESCRIPTION
Parent status is now determined by linked children data, not a signup role. Removed parent option from RoleSelectionModal and parent icon case from SignupStep2Form.